### PR TITLE
Add Cloud Agent development environment

### DIFF
--- a/.cursor/environment.json
+++ b/.cursor/environment.json
@@ -1,0 +1,11 @@
+{
+  "name": "DeepTerm",
+  "user": "ubuntu",
+  "install": "bash .cursor/install.sh",
+  "terminals": [
+    {
+      "name": "dev",
+      "command": "export BUN_INSTALL=\"$HOME/.bun\" && export PATH=\"$BUN_INSTALL/bin:$PATH\" && bun run dev"
+    }
+  ]
+}

--- a/.cursor/install.sh
+++ b/.cursor/install.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Bun is the project's package manager, test runner, and dev runtime.
+# Install it once (idempotent) into the user's home, which is captured by the
+# environment snapshot so subsequent boots reuse it.
+if [ ! -x "$HOME/.bun/bin/bun" ]; then
+  curl -fsSL https://bun.sh/install | bash
+fi
+
+export BUN_INSTALL="$HOME/.bun"
+export PATH="$BUN_INSTALL/bin:$PATH"
+
+bun --version
+bun install --frozen-lockfile


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds a Cloud Agent environment configuration so DeepTerm is usable in fresh agent VMs.

- `.cursor/environment.json` — keeps Cursor's default base image (includes Chrome for GUI testing), runs the install script, and starts the Next.js dev server (`bun run dev`) as a visible `dev` terminal.
- `.cursor/install.sh` — idempotently installs Bun (the project's package manager, test runner, and dev runtime) and runs `bun install --frozen-lockfile`.

## Validation (current VM)

- `bun install --frozen-lockfile` — completes; idempotent on re-run (no lockfile changes).
- `bun test` — 486 pass, 0 fail (27 files).
- `bun run lint` — 0 errors (2 pre-existing warnings).
- `bun run dev` — boots; all public routes (`/`, `/about`, `/blog`, `/help`, `/changelog`, `/terms`, `/privacy-policy`) return `200` once Supabase env vars are present.

## Required secrets (exact names the code reads)

The code reads these names (the README lists older `..._ANON_KEY` / `..._SERVICE_ROLE_KEY` names, which are outdated):

- `NEXT_PUBLIC_SUPABASE_URL`
- `NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY`
- `SUPABASE_SECRET_KEY`
- `GEMINI_API_KEY` (or `GEMINI_API_KEY_1` … `GEMINI_API_KEY_5`)

Optional: `NEXT_PUBLIC_TURNSTILE_SITE_KEY`, `TURNSTILE_SECRET`, `TURNSTILE_HOSTNAMES`, `UNSPLASH_ACCESS_KEY`, `NEXT_PUBLIC_POSTHOG_KEY`, `NEXT_PUBLIC_POSTHOG_HOST`, `CRON_SECRET`.

The Next.js middleware (`src/proxy.ts`) creates a Supabase client on every request, so the Supabase vars are required for any route to render.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-cb3ba93a-e45b-4cf5-91c0-cdb9b00f7ffd?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-cb3ba93a-e45b-4cf5-91c0-cdb9b00f7ffd&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

