### PR TITLE
Fix share, study, AI, and auth bugs from feature audit

### DIFF
--- a/src/app/(dashboard)/account/page.tsx
+++ b/src/app/(dashboard)/account/page.tsx
@@ -173,7 +173,12 @@ export default function AccountPage() {
             setMessage({ type: "error", text: "Failed to cancel deletion. Please try again." });
             return;
         }
-        setDeletion({ pending: false });
+        const status = await getAccountDeletionStatusAction();
+        setDeletion({
+            pending: status.pending,
+            deletedAt: status.deletedAt,
+            finalizeAt: status.finalizeAt,
+        });
         setMessage({ type: "success", text: "Deletion cancelled. Your account is safe." });
     };
 

--- a/src/app/(dashboard)/materials/MaterialsClient.tsx
+++ b/src/app/(dashboard)/materials/MaterialsClient.tsx
@@ -15,6 +15,7 @@ import {
 import { useRouter } from "next/navigation";
 import { useMaterialsStore } from "@/lib/stores";
 import type { MaterialItem, MaterialFilter } from "@/lib/schemas/materials";
+import { matchesMaterialFilter, selectMaterialSourceItems } from "@/utils/materialFilter";
 
 interface MaterialsClientProps {
     initialItems: MaterialItem[];
@@ -66,21 +67,16 @@ export default function MaterialsClient({ initialItems }: MaterialsClientProps) 
         removeItem
     } = useMaterialsStore();
 
-    // Initialize store with server data (one-time, synchronously during render)
-    if (!initialized && initialItems.length > 0) {
+    if (!initialized) {
         setItems(initialItems);
         setInitialized(true);
     }
 
-    // Use initialItems for first render to avoid hydration mismatch
-    const sourceItems = items.length > 0 ? items : initialItems;
+    const sourceItems = selectMaterialSourceItems(initialized, items, initialItems);
 
-    // Apply filters locally
     const filteredItems = sourceItems.filter((item: MaterialItem) => {
         const matchesSearch = item.title.toLowerCase().includes(searchQuery.toLowerCase());
-        const matchesFilter = activeFilter === 'All' ||
-            (activeFilter === 'Cards' && item.type === 'Flashcards') ||
-            item.type === activeFilter;
+        const matchesFilter = matchesMaterialFilter(item.type, activeFilter);
         return matchesSearch && matchesFilter;
     });
 
@@ -89,8 +85,10 @@ export default function MaterialsClient({ initialItems }: MaterialsClientProps) 
     const handleDelete = async (item: MaterialItem) => {
         const supabase = createClient();
         const table = item.type === "Flashcards" ? "flashcard_sets" : "reviewers";
-        await supabase.from(table).delete().eq("id", item.id);
-        removeItem(item.id);
+        const { error } = await supabase.from(table).delete().eq("id", item.id);
+        if (!error) {
+            removeItem(item.id);
+        }
     };
 
     return (

--- a/src/app/(dashboard)/materials/[id]/MaterialDetailClient.tsx
+++ b/src/app/(dashboard)/materials/[id]/MaterialDetailClient.tsx
@@ -30,6 +30,7 @@ import {
 import StudyingProgress from "@/components/StudyingProgress";
 import ShareModal from "@/components/ShareModal";
 import { createClient } from "@/config/supabase/client";
+import { buildReviewerTermInsert } from "@/utils/reviewerTerms";
 
 type LearnStage = 'new' | 'learning' | 'review' | 'mastered';
 
@@ -492,9 +493,11 @@ export default function MaterialDetailClient(props: Props) {
 
     const handleAddReviewerTerm = useCallback(async (categoryId: string, term: string, definition: string) => {
         const supabase = createClient();
+        const { data: { user } } = await supabase.auth.getUser();
+        if (!user) return;
         const { data: newTerm } = await supabase
             .from("reviewer_terms")
-            .insert({ category_id: categoryId, term, definition })
+            .insert(buildReviewerTermInsert(user.id, categoryId, term, definition))
             .select()
             .single();
         if (newTerm) {

--- a/src/app/(dashboard)/materials/[id]/flashcards/page.tsx
+++ b/src/app/(dashboard)/materials/[id]/flashcards/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useCallback, useEffect } from "react";
+import { useState, useCallback } from "react";
 import { motion } from "framer-motion";
 import { useRouter, useParams } from "next/navigation";
 import { RotateCcw, Check, X, Settings, Loader2 } from "lucide-react";
@@ -69,9 +69,7 @@ export default function FlashcardsPage() {
         setIsLoading(false);
     }, [params.id]);
 
-    useEffect(() => {
-        void fetchCards();
-    }, [fetchCards]);
+    useState(() => { fetchCards(); });
 
     // Get XP stats from store - must be called before any early returns
     const xpStats = useXPStore((state) => state.stats);

--- a/src/app/(dashboard)/materials/[id]/flashcards/page.tsx
+++ b/src/app/(dashboard)/materials/[id]/flashcards/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useCallback } from "react";
+import { useState, useCallback, useEffect } from "react";
 import { motion } from "framer-motion";
 import { useRouter, useParams } from "next/navigation";
 import { RotateCcw, Check, X, Settings, Loader2 } from "lucide-react";
@@ -69,7 +69,9 @@ export default function FlashcardsPage() {
         setIsLoading(false);
     }, [params.id]);
 
-    useState(() => { fetchCards(); });
+    useEffect(() => {
+        void fetchCards();
+    }, [fetchCards]);
 
     // Get XP stats from store - must be called before any early returns
     const xpStats = useXPStore((state) => state.stats);

--- a/src/app/(dashboard)/materials/[id]/learn/page.tsx
+++ b/src/app/(dashboard)/materials/[id]/learn/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useCallback, useSyncExternalStore } from "react";
+import { useState, useCallback, useEffect, useSyncExternalStore } from "react";
 import { motion, AnimatePresence } from "framer-motion";
 import { useRouter, useParams } from "next/navigation";
 import {
@@ -14,6 +14,7 @@ import { getStudySettings, getQuestionTypeForStage, StudySettings, QuestionType 
 import { createClient } from "@/config/supabase/client";
 import { useXPStore } from "@/lib/stores";
 import { addXP, recordStudyActivity, batchUpdateFlashcardStatuses, XP_REWARDS, type FlashcardStatusUpdate } from "@/services/activity";
+import { expectedWrittenAnswer, promptLabelForFrontSide } from "@/utils/reviewerTerms";
 
 type LearnStage = 'new' | 'learning' | 'almost_done' | 'mastered';
 
@@ -78,6 +79,7 @@ export default function LearnPage() {
     const router = useRouter();
     const params = useParams();
     const [isLoading, setIsLoading] = useState(true);
+    const [materialTitle, setMaterialTitle] = useState("Learn");
     const [settings, setSettings] = useState<StudySettings>(() => getStudySettings());
     const [cards, setCards] = useState<LearnCard[]>([]);
     const [sessionQueue, setSessionQueue] = useState<SessionCard[]>([]);
@@ -87,11 +89,22 @@ export default function LearnPage() {
         useXPStore.getState().fetchXPStats();
 
         const supabase = createClient();
-        const { data } = await supabase
-            .from("flashcards")
-            .select("id, front, back, status")
-            .eq("set_id", params.id)
-            .order("created_at");
+        const [{ data }, { data: setRow }] = await Promise.all([
+            supabase
+                .from("flashcards")
+                .select("id, front, back, status")
+                .eq("set_id", params.id)
+                .order("created_at"),
+            supabase
+                .from("flashcard_sets")
+                .select("title")
+                .eq("id", params.id)
+                .maybeSingle(),
+        ]);
+
+        if (setRow?.title) {
+            setMaterialTitle(setRow.title);
+        }
 
         if (data && data.length > 0) {
             const loadedCards: LearnCard[] = data.map(c => ({
@@ -106,7 +119,9 @@ export default function LearnPage() {
         setIsLoading(false);
     }, [params.id]);
 
-    useState(() => { fetchCards(); });
+    useEffect(() => {
+        void fetchCards();
+    }, [fetchCards]);
     const [currentIndex, setCurrentIndex] = useState(0);
     const [isFlipped, setIsFlipped] = useState(false);
     const [writtenAnswer, setWrittenAnswer] = useState("");
@@ -285,7 +300,8 @@ export default function LearnPage() {
 
     const handleWrittenSubmit = () => {
         const currentCard = sessionQueue[currentIndex];
-        const correct = writtenAnswer.trim().toLowerCase() === currentCard.term.toLowerCase();
+        const expected = expectedWrittenAnswer(settings.frontSide, currentCard);
+        const correct = writtenAnswer.trim().toLowerCase() === expected.toLowerCase();
         setWrittenCorrect(correct);
         setWrittenSubmitted(true);
         setJustSubmittedWritten(true);
@@ -483,7 +499,7 @@ export default function LearnPage() {
                 </div>
 
                 <h1 className="font-sora font-bold text-[#171d2b] text-base sm:text-lg absolute left-1/2 transform -translate-x-1/2 truncate max-w-[40%]">
-                    DSA MIDTERMS
+                    {materialTitle}
                 </h1>
 
                 <div className="flex items-center gap-2 sm:gap-3">
@@ -512,7 +528,7 @@ export default function LearnPage() {
                 {/* Question Card */}
                 <div className="w-full max-w-3xl bg-white rounded-2xl sm:rounded-3xl shadow-sm border border-gray-100 p-4 sm:p-8 min-h-[200px] sm:min-h-[300px] flex flex-col relative mb-4 sm:mb-8">
                     <div className="flex justify-between items-start mb-4 sm:mb-6">
-                        <span className="text-xs sm:text-sm font-medium text-gray-500">Definition</span>
+                        <span className="text-xs sm:text-sm font-medium text-gray-500">{promptLabelForFrontSide(settings.frontSide)}</span>
                         <div className="flex items-center gap-2">
                             {currentCard.stage === 'new' && (
                                 <span className="px-2 sm:px-3 py-1 bg-pink-100 text-pink-600 text-xs font-bold rounded-full flex items-center gap-1">

--- a/src/app/(dashboard)/materials/[id]/learn/page.tsx
+++ b/src/app/(dashboard)/materials/[id]/learn/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useCallback, useEffect, useSyncExternalStore } from "react";
+import { useState, useCallback, useSyncExternalStore } from "react";
 import { motion, AnimatePresence } from "framer-motion";
 import { useRouter, useParams } from "next/navigation";
 import {
@@ -119,9 +119,7 @@ export default function LearnPage() {
         setIsLoading(false);
     }, [params.id]);
 
-    useEffect(() => {
-        void fetchCards();
-    }, [fetchCards]);
+    useState(() => { fetchCards(); });
     const [currentIndex, setCurrentIndex] = useState(0);
     const [isFlipped, setIsFlipped] = useState(false);
     const [writtenAnswer, setWrittenAnswer] = useState("");

--- a/src/app/(dashboard)/materials/[id]/match/page.tsx
+++ b/src/app/(dashboard)/materials/[id]/match/page.tsx
@@ -9,6 +9,7 @@ import ExitPopup from "@/components/ExitPopup";
 import { createClient } from "@/config/supabase/client";
 import { useXPStore } from "@/lib/stores";
 import { addXP, recordStudyActivity, updateFlashcardStatus, XP_REWARDS } from "@/services/activity";
+import { createGameCards } from "@/utils/matchGame";
 
 type CardStatus = 'new' | 'learning' | 'review' | 'mastered';
 
@@ -29,16 +30,6 @@ interface MatchCard {
 
 type Stage = "loading" | "playing" | "results";
 
-function createGameCards(data: FlashcardData[]): MatchCard[] {
-    const gameCards: MatchCard[] = [];
-    const selected = data.slice(0, 6);
-    selected.forEach(item => {
-        gameCards.push({ id: `term-${item.id}`, content: item.term, type: 'term', pairId: item.id, isMatched: false });
-        gameCards.push({ id: `def-${item.id}`, content: item.definition, type: 'definition', pairId: item.id, isMatched: false });
-    });
-    return gameCards.sort(() => Math.random() - 0.5);
-}
-
 export default function MatchPage() {
     const router = useRouter();
     const params = useParams();
@@ -53,6 +44,7 @@ export default function MatchPage() {
     const [finalTime, setFinalTime] = useState(0);
     const [showExitPopup, setShowExitPopup] = useState(false);
     const timerRef = useRef<NodeJS.Timeout | null>(null);
+    const timeElapsedRef = useRef(0);
 
     useEffect(() => {
         let mounted = true;
@@ -80,7 +72,11 @@ export default function MatchPage() {
                 setFlashcardData(fcData);
                 setCards(createGameCards(fcData));
                 setStage("playing");
-                timerRef.current = setInterval(() => setTimeElapsed(prev => prev + 0.1), 100);
+                timeElapsedRef.current = 0;
+                timerRef.current = setInterval(() => {
+                    timeElapsedRef.current += 0.1;
+                    setTimeElapsed(timeElapsedRef.current);
+                }, 100);
             } else {
                 setStage("playing");
             }
@@ -115,7 +111,11 @@ export default function MatchPage() {
         setFinalXpEarned(0);
         setFinalTime(0);
         setStage("playing");
-        timerRef.current = setInterval(() => setTimeElapsed(prev => prev + 0.1), 100);
+        timeElapsedRef.current = 0;
+        timerRef.current = setInterval(() => {
+            timeElapsedRef.current += 0.1;
+            setTimeElapsed(timeElapsedRef.current);
+        }, 100);
     }, [stopTimer, flashcardData]);
 
     const handleCardClick = (card: MatchCard) => {
@@ -146,11 +146,10 @@ export default function MatchPage() {
                     setSelectedCards([]);
 
                     if (allMatched) {
-                        // Stop timer and capture final time in state
                         stopTimer();
-                        setFinalTime(timeElapsed);
+                        const completedTime = timeElapsedRef.current;
+                        setFinalTime(completedTime);
 
-                        // Persist XP at moment of completion (not during render)
                         const newMatchCount = matchCount + 1;
                         const xpEarned = newMatchCount * XP_REWARDS.FLASHCARD_CORRECT;
                         setFinalXpEarned(xpEarned);
@@ -160,7 +159,7 @@ export default function MatchPage() {
                                 await addXP(xpEarned);
                                 useXPStore.getState().fetchXPStats();
                             }
-                            const minutesStudied = Math.max(1, Math.round(timeElapsed / 60));
+                            const minutesStudied = Math.max(1, Math.round(completedTime / 60));
                             await recordStudyActivity({ flashcards: newMatchCount, minutes: minutesStudied });
                         };
                         persistResults();
@@ -195,7 +194,7 @@ export default function MatchPage() {
             id: item.id,
             term: item.term,
             definition: item.definition,
-            status: 'new' as 'new' | 'learning' | 'almost_done' | 'mastered'
+            status: (item.status === 'review' ? 'almost_done' : item.status) as 'new' | 'learning' | 'almost_done' | 'mastered'
         }));
 
         return (

--- a/src/app/(dashboard)/materials/[id]/practice/page.tsx
+++ b/src/app/(dashboard)/materials/[id]/practice/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useCallback, useEffect, useRef } from "react";
+import { useState, useCallback, useRef } from "react";
 import { useRouter, useParams } from "next/navigation";
 import { motion, AnimatePresence } from "framer-motion";
 import { X, Loader2 } from "lucide-react";
@@ -85,9 +85,7 @@ export default function PracticePage() {
         }
     }, [params.id]);
 
-    useEffect(() => {
-        void fetchCards();
-    }, [fetchCards]);
+    useState(() => { fetchCards(); });
     const [currentQuestionIndex, setCurrentQuestionIndex] = useState(0);
     const [showAnswer, setShowAnswer] = useState(false);
     const [streak, setStreak] = useState(0);

--- a/src/app/(dashboard)/materials/[id]/practice/page.tsx
+++ b/src/app/(dashboard)/materials/[id]/practice/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useCallback, useRef } from "react";
+import { useState, useCallback, useEffect, useRef } from "react";
 import { useRouter, useParams } from "next/navigation";
 import { motion, AnimatePresence } from "framer-motion";
 import { X, Loader2 } from "lucide-react";
@@ -11,8 +11,7 @@ import PracticeSettingsModal, { PracticeSettings } from "@/components/PracticeSe
 import { createClient } from "@/config/supabase/client";
 import { useXPStore } from "@/lib/stores";
 import { addXP, recordStudyActivity, batchUpdateFlashcardStatuses, XP_REWARDS, type FlashcardStatusUpdate } from "@/services/activity";
-
-type QuestionType = "multipleChoice" | "trueFalse" | "fillBlank";
+import { generateQuestionsFromCards, gradePracticeAnswer, type QuestionType } from "@/utils/practiceQuestions";
 
 type CardStatus = 'new' | 'learning' | 'review' | 'mastered';
 
@@ -54,60 +53,6 @@ const DEFAULT_PRACTICE_SETTINGS: PracticeSettings = {
     answerFeedback: false,
 };
 
-function generateQuestionsFromCards(cards: FlashcardData[], types: QuestionType[], cardCount: number): Question[] {
-    const questions: Question[] = [];
-    const shuffled = [...cards].sort(() => Math.random() - 0.5);
-    const selectedCards = shuffled.slice(0, cardCount);
-
-    selectedCards.forEach((card, idx) => {
-        const type = types[idx % types.length];
-
-        if (type === 'trueFalse') {
-            // True/False: Show definition, display a term, ask if it's correct
-            const isCorrectPairing = Math.random() > 0.5;
-            let displayedTerm: string;
-
-            if (isCorrectPairing) {
-                displayedTerm = card.term;
-            } else {
-                const others = cards.filter(c => c.id !== card.id);
-                displayedTerm = others.length > 0
-                    ? others[Math.floor(Math.random() * others.length)].term
-                    : card.term;
-            }
-
-            questions.push({
-                id: card.id,
-                type,
-                question: card.definition,
-                correctAnswer: isCorrectPairing ? 'true' : 'false',
-                tfDisplayedTerm: displayedTerm,
-                tfIsCorrectPairing: isCorrectPairing,
-            });
-        } else if (type === 'fillBlank') {
-            questions.push({
-                id: card.id,
-                type,
-                question: `${card.definition.split(' ').slice(0, 3).join(' ')} _____ ${card.definition.split(' ').slice(-2).join(' ')}`,
-                correctAnswer: card.term.toLowerCase(),
-            });
-        } else {
-            // Multiple choice - show definition, ask for term (like learn mode)
-            const others = cards.filter(c => c.id !== card.id).map(c => c.term);
-            const wrongOptions = others.sort(() => Math.random() - 0.5).slice(0, 3);
-            questions.push({
-                id: card.id,
-                type,
-                question: card.definition,
-                correctAnswer: card.term,
-                options: [...wrongOptions, card.term].sort(() => Math.random() - 0.5),
-            });
-        }
-    });
-
-    return questions;
-}
-
 export default function PracticePage() {
     const router = useRouter();
     const params = useParams();
@@ -140,7 +85,9 @@ export default function PracticePage() {
         }
     }, [params.id]);
 
-    useState(() => { fetchCards(); });
+    useEffect(() => {
+        void fetchCards();
+    }, [fetchCards]);
     const [currentQuestionIndex, setCurrentQuestionIndex] = useState(0);
     const [showAnswer, setShowAnswer] = useState(false);
     const [streak, setStreak] = useState(0);
@@ -210,9 +157,7 @@ export default function PracticePage() {
         const updated = [...questions];
         updated[currentQuestionIndex].userAnswer = answer;
         const current = updated[currentQuestionIndex];
-        const isCorrect = current.type === "fillBlank"
-            ? answer.toLowerCase().trim().includes(current.correctAnswer.toLowerCase().trim().split(" ")[0])
-            : answer.toLowerCase() === current.correctAnswer.toLowerCase();
+        const isCorrect = gradePracticeAnswer(current.type, answer, current.correctAnswer);
         updated[currentQuestionIndex].isCorrect = isCorrect;
         setQuestions(updated);
 

--- a/src/app/api/generate-cards/route.ts
+++ b/src/app/api/generate-cards/route.ts
@@ -3,19 +3,17 @@ import { FileState } from "@google/genai";
 import { checkAndIncrementAIUsage } from "@/services/rateLimit";
 import { generateContentWithRotation, uploadFileWithRotation, getApiKeyCount, Type } from "@/services/geminiClient";
 import { verifyTurnstileToken } from "@/services/turnstile";
+import { MAX_CARDS_FILE_SIZE, MAX_GENERATE_TEXT_LENGTH, resolveGenerateMimeType } from "@/utils/generateInput";
 import { z } from "zod";
 
 // File size limits (in bytes)
-const MAX_FILE_SIZE = 20 * 1024 * 1024; // 20MB
-const MAX_TEXT_LENGTH = 100000; // 100k characters
+const MAX_FILE_SIZE = MAX_CARDS_FILE_SIZE;
+const MAX_TEXT_LENGTH = MAX_GENERATE_TEXT_LENGTH;
 
 // Zod schema for input validation
 const GenerateCardsInputSchema = z.object({
   textContent: z.string().max(MAX_TEXT_LENGTH, `Text too long. Maximum length is ${MAX_TEXT_LENGTH} characters`).optional().nullable(),
 });
-
-// Allowed MIME types whitelist
-const ALLOWED_MIME_TYPES = ["application/pdf"] as const;
 
 // Structured output schema for flashcards - enforces non-empty term and definition
 const flashcardResponseSchema = {
@@ -54,25 +52,6 @@ export async function POST(request: NextRequest) {
     return NextResponse.json({ error: captcha.error }, { status: captcha.status });
   }
 
-  // Atomic rate limit check and increment
-  const rateLimit = await checkAndIncrementAIUsage();
-  
-  // Check authentication first
-  if (!rateLimit.authenticated) {
-    return NextResponse.json({
-      error: "Not authenticated"
-    }, { status: 401 });
-  }
-  
-  // Then check rate limit
-  if (!rateLimit.allowed) {
-    return NextResponse.json({
-      error: "Daily AI generation limit reached (10/day)",
-      remaining: rateLimit.remaining,
-      resetAt: rateLimit.resetAt.toISOString()
-    }, { status: 429 });
-  }
-
   try {
     const file = formData.get("file") as File | null;
     const rawTextContent = formData.get("textContent");
@@ -103,29 +82,51 @@ export async function POST(request: NextRequest) {
     }
 
     // MIME type validation against whitelist
-    if (file) {
-      const mimeType = file.type || getMimeTypeFromName(file.name);
-      if (!mimeType || !ALLOWED_MIME_TYPES.includes(mimeType as typeof ALLOWED_MIME_TYPES[number])) {
-        return NextResponse.json({ error: "Unsupported file type. Only PDF files are allowed." }, { status: 400 });
-      }
+    const resolvedMimeType = file ? resolveGenerateMimeType(file) : null;
+    if (file && !resolvedMimeType) {
+      return NextResponse.json({ error: "Unsupported file type. Only PDF files are allowed." }, { status: 400 });
+    }
+
+    // Consume quota only after the request is known to be valid
+    const rateLimit = await checkAndIncrementAIUsage();
+
+    if (!rateLimit.authenticated) {
+      return NextResponse.json({
+        error: "Not authenticated"
+      }, { status: 401 });
+    }
+
+    if (rateLimit.unavailable) {
+      return NextResponse.json({
+        error: "Rate limit service unavailable. Please try again."
+      }, { status: 503 });
+    }
+
+    if (!rateLimit.allowed) {
+      return NextResponse.json({
+        error: "Daily AI generation limit reached (10/day)",
+        remaining: rateLimit.remaining,
+        resetAt: rateLimit.resetAt.toISOString()
+      }, { status: 429 });
     }
 
     let fileUri: string | null = null;
     let mimeType: string | null = null;
+    let uploadKeyIndex = 0;
 
     // Handle file upload to Gemini Files API
     if (file) {
-      mimeType = file.type || getMimeTypeFromName(file.name);
-      // MIME type already validated above, safe to assert non-null
-      const validMimeType = mimeType!;
+      const validMimeType = resolvedMimeType!;
+      mimeType = validMimeType;
 
       const arrayBuffer = await file.arrayBuffer();
       const blob = new Blob([arrayBuffer], { type: validMimeType });
 
-      const { uploadedFile, ai } = await uploadFileWithRotation({
+      const { uploadedFile, ai, keyIndex } = await uploadFileWithRotation({
         file: blob,
         config: { mimeType: validMimeType, displayName: file.name },
       });
+      uploadKeyIndex = keyIndex;
 
       // Wait for file processing
       let geminiFile = await ai.files.get({ name: uploadedFile.name! });
@@ -197,6 +198,7 @@ MANDATORY:
     const { text: responseText } = await generateContentWithRotation({
       model: "gemini-2.5-flash-lite",
       contents,
+      preferredKeyIndex: uploadKeyIndex,
       config: {
         systemInstruction: systemPrompt,
         temperature: 0.2,
@@ -258,10 +260,3 @@ MANDATORY:
   }
 }
 
-function getMimeTypeFromName(filename: string): string | null {
-  const ext = filename.toLowerCase().split(".").pop();
-  switch (ext) {
-    case "pdf": return "application/pdf";
-    default: return null;
-  }
-}

--- a/src/app/api/generate-reviewer/route.ts
+++ b/src/app/api/generate-reviewer/route.ts
@@ -3,10 +3,11 @@ import { FileState } from "@google/genai";
 import { checkAndIncrementAIUsage } from "@/services/rateLimit";
 import { generateContentWithRotation, uploadFileWithRotation, getApiKeyCount, Type } from "@/services/geminiClient";
 import { verifyTurnstileToken } from "@/services/turnstile";
+import { MAX_GENERATE_TEXT_LENGTH, MAX_REVIEWER_FILE_SIZE, resolveGenerateMimeType } from "@/utils/generateInput";
 
 // File size limits (in bytes)
-const MAX_FILE_SIZE = 10 * 1024 * 1024; // 10MB - reduced for faster processing
-const MAX_TEXT_LENGTH = 100000; // 100k characters
+const MAX_FILE_SIZE = MAX_REVIEWER_FILE_SIZE;
+const MAX_TEXT_LENGTH = MAX_GENERATE_TEXT_LENGTH;
 
 // Valid extraction modes
 const VALID_EXTRACTION_MODES = ['full', 'sentence', 'keywords'] as const;
@@ -91,25 +92,6 @@ export async function POST(request: NextRequest) {
         return NextResponse.json({ error: captcha.error }, { status: captcha.status });
     }
 
-    // Atomic rate limit check and increment
-    const rateLimit = await checkAndIncrementAIUsage();
-    
-    // Check authentication first
-    if (!rateLimit.authenticated) {
-        return NextResponse.json({
-            error: "Not authenticated"
-        }, { status: 401 });
-    }
-    
-    // Then check rate limit
-    if (!rateLimit.allowed) {
-        return NextResponse.json({ 
-            error: "Daily AI generation limit reached (10/day)", 
-            remaining: rateLimit.remaining,
-            resetAt: rateLimit.resetAt.toISOString()
-        }, { status: 429 });
-    }
-
     try {
         const file = formData.get("file") as File | null;
         const textContent = formData.get("textContent") as string | null;
@@ -138,23 +120,49 @@ export async function POST(request: NextRequest) {
             }, { status: 400 });
         }
 
+        const resolvedMimeType = file ? resolveGenerateMimeType(file) : null;
+        if (file && !resolvedMimeType) {
+            return NextResponse.json({ error: "Unsupported file type. Only PDF files are allowed." }, { status: 400 });
+        }
+
+        const rateLimit = await checkAndIncrementAIUsage();
+
+        if (!rateLimit.authenticated) {
+            return NextResponse.json({
+                error: "Not authenticated"
+            }, { status: 401 });
+        }
+
+        if (rateLimit.unavailable) {
+            return NextResponse.json({
+                error: "Rate limit service unavailable. Please try again."
+            }, { status: 503 });
+        }
+
+        if (!rateLimit.allowed) {
+            return NextResponse.json({ 
+                error: "Daily AI generation limit reached (10/day)", 
+                remaining: rateLimit.remaining,
+                resetAt: rateLimit.resetAt.toISOString()
+            }, { status: 429 });
+        }
+
         let fileUri: string | null = null;
         let mimeType: string | null = null;
+        let uploadKeyIndex = 0;
 
         // Handle file upload to Gemini Files API
         if (file) {
-            mimeType = file.type || getMimeTypeFromName(file.name);
-            if (!mimeType) {
-                return NextResponse.json({ error: "Unsupported file type. Only PDF files are allowed." }, { status: 400 });
-            }
+            mimeType = resolvedMimeType;
 
             const arrayBuffer = await file.arrayBuffer();
             const blob = new Blob([arrayBuffer], { type: mimeType });
 
-            const { uploadedFile, ai } = await uploadFileWithRotation({
+            const { uploadedFile, ai, keyIndex } = await uploadFileWithRotation({
                 file: blob,
-                config: { mimeType, displayName: file.name },
+                config: { mimeType: mimeType!, displayName: file.name },
             });
+            uploadKeyIndex = keyIndex;
 
             // Wait for file processing
             let geminiFile = await ai.files.get({ name: uploadedFile.name! });
@@ -241,6 +249,7 @@ COLOR OPTIONS for categories: #E0F2FE, #DCFCE7, #FEF3C7, #FCE7F3, #E0E7FF, #F3E8
         const { text: responseText } = await generateContentWithRotation({
             model: "gemini-2.5-flash-lite",
             contents,
+            preferredKeyIndex: uploadKeyIndex,
             config: {
                 systemInstruction: systemPrompt,
                 temperature: 0.5,
@@ -341,10 +350,3 @@ COLOR OPTIONS for categories: #E0F2FE, #DCFCE7, #FEF3C7, #FCE7F3, #E0E7FF, #F3E8
     }
 }
 
-function getMimeTypeFromName(filename: string): string | null {
-    const ext = filename.toLowerCase().split(".").pop();
-    switch (ext) {
-        case "pdf": return "application/pdf";
-        default: return null;
-    }
-}

--- a/src/app/api/generate-reviewer/route.ts
+++ b/src/app/api/generate-reviewer/route.ts
@@ -156,7 +156,7 @@ export async function POST(request: NextRequest) {
             mimeType = resolvedMimeType;
 
             const arrayBuffer = await file.arrayBuffer();
-            const blob = new Blob([arrayBuffer], { type: mimeType });
+            const blob = new Blob([arrayBuffer], { type: mimeType ?? undefined });
 
             const { uploadedFile, ai, keyIndex } = await uploadFileWithRotation({
                 file: blob,

--- a/src/app/api/share/route.ts
+++ b/src/app/api/share/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { createServerSupabaseClient } from '@/config/supabase/server'
-import { ShareCodeCreateSchema, ShareMaterialTypeSchema } from '@/lib/schemas/sharing'
+import { ShareCodeCreateSchema, ShareMaterialTypeSchema, ShareGetQuerySchema, SharePatchSchema } from '@/lib/schemas/sharing'
 import { z } from 'zod'
 
 const SHARE_CODE_ALPHABET = 'abcdefghijklmnopqrstuvwxyz0123456789'
@@ -68,12 +68,16 @@ export async function GET(request: NextRequest) {
   }
 
   const { searchParams } = new URL(request.url)
-  const materialType = searchParams.get('materialType')
-  const materialId = searchParams.get('materialId')
+  const parsedQuery = ShareGetQuerySchema.safeParse({
+    materialType: searchParams.get('materialType'),
+    materialId: searchParams.get('materialId'),
+  })
 
-  if (!materialType || !materialId) {
-    return NextResponse.json({ error: 'Missing parameters' }, { status: 400 })
+  if (!parsedQuery.success) {
+    return NextResponse.json({ error: 'Missing or invalid parameters' }, { status: 400 })
   }
+
+  const { materialType, materialId } = parsedQuery.data
 
   // Optimized: only select needed columns
   const { data: share } = await supabase
@@ -125,7 +129,8 @@ export async function POST(request: NextRequest) {
     .select('id, share_code, is_active, created_at')
     .eq('material_type', materialType)
     .eq('material_id', materialId)
-    .single()
+    .eq('user_id', user.id)
+    .maybeSingle()
 
   if (existing) {
     // Reactivate if inactive
@@ -199,11 +204,13 @@ export async function PATCH(request: NextRequest) {
   }
 
   const body = await request.json()
-  const { shareId, isActive, newCode } = body
+  const parsed = SharePatchSchema.safeParse(body)
 
-  if (!shareId) {
-    return NextResponse.json({ error: 'Missing shareId' }, { status: 400 })
+  if (!parsed.success) {
+    return NextResponse.json({ error: parsed.error.flatten() }, { status: 400 })
   }
+
+  const { shareId, isActive, newCode } = parsed.data
 
   const updates: Record<string, unknown> = { updated_at: new Date().toISOString() }
 

--- a/src/app/auth/callback/route.ts
+++ b/src/app/auth/callback/route.ts
@@ -1,76 +1,26 @@
 import { createServerSupabaseClient } from '@/config/supabase/server'
 import { NextResponse } from 'next/server'
-
-// Trusted origins — prevents host header injection (CWE-644)
-const TRUSTED_ORIGINS = [
-  'https://deepterm.app',
-  'https://www.deepterm.app',
-  'https://deepterm.vercel.app',
-]
-
-/**
- * Returns a trusted origin, falling back to the primary domain.
- * Prevents host header injection by ignoring untrusted request origins.
- */
-function getTrustedOrigin(requestUrl: URL): string {
-  const requestOrigin = requestUrl.origin
-
-  // In development, allow localhost
-  if (process.env.NODE_ENV === 'development' && requestOrigin.startsWith('http://localhost')) {
-    return requestOrigin
-  }
-
-  if (TRUSTED_ORIGINS.includes(requestOrigin)) {
-    return requestOrigin
-  }
-
-  // Fallback to primary domain — never trust an unknown Host header
-  return TRUSTED_ORIGINS[0]
-}
-
-/**
- * Validates that a redirect path is safe (relative, no open redirect).
- * Returns the sanitized path or '/dashboard' if invalid.
- */
-function sanitizeRedirectPath(raw: string | null): string {
-  if (!raw) return '/dashboard'
-
-  let decoded: string
-  try {
-    decoded = decodeURIComponent(raw)
-  } catch {
-    return '/dashboard'
-  }
-
-  // Must start with exactly one slash (reject protocol-relative "//evil.com")
-  if (!decoded.startsWith('/') || decoded.startsWith('//')) {
-    return '/dashboard'
-  }
-
-  // Block embedded protocol schemes (e.g. "/\x00javascript:", "/%0ahttp:")
-  if (/[a-z]+:/i.test(decoded.replace(/^\//, ''))) {
-    return '/dashboard'
-  }
-
-  return decoded
-}
+import { getTrustedOrigin } from '@/lib/auth/trustedOrigins'
+import { resolveAuthCallbackPath } from '@/lib/auth/redirect'
 
 export async function GET(request: Request) {
   const requestUrl = new URL(request.url)
   const code = requestUrl.searchParams.get('code')
   const returnTo = requestUrl.searchParams.get('returnTo')
-  const origin = getTrustedOrigin(requestUrl)
+  const origin = getTrustedOrigin(requestUrl.origin, process.env.NODE_ENV === 'development')
 
-  if (code) {
-    const supabase = await createServerSupabaseClient()
-    const { error } = await supabase.auth.exchangeCodeForSession(code)
-
-    if (error) {
-      console.error('Auth callback: session exchange failed', error.message)
-      return NextResponse.redirect(`${origin}/`)
-    }
+  if (!code) {
+    return NextResponse.redirect(`${origin}${resolveAuthCallbackPath({ hasCode: false })}`)
   }
 
-  const redirectPath = sanitizeRedirectPath(returnTo)
+  const supabase = await createServerSupabaseClient()
+  const { error } = await supabase.auth.exchangeCodeForSession(code)
+
+  if (error) {
+    console.error('Auth callback: session exchange failed', error.message)
+    return NextResponse.redirect(`${origin}${resolveAuthCallbackPath({ hasCode: true, exchangeFailed: true })}`)
+  }
+
+  const redirectPath = resolveAuthCallbackPath({ hasCode: true, returnTo })
   return NextResponse.redirect(`${origin}${redirectPath}`)
 }

--- a/src/app/share/[code]/page.tsx
+++ b/src/app/share/[code]/page.tsx
@@ -7,6 +7,7 @@ import { siteConfig } from '@/lib/seo'
 import { ShareCodeSchema } from '@/lib/schemas/sharing'
 import { checkShareRateLimit, getRequestIdentifier } from '@/services/shareRateLimit'
 import { hashRequestIdentity } from '@/lib/auth/requestIdentity'
+import { buildSharePageMeta, parseSharedMaterial } from '@/utils/shareMetadata'
 
 interface PageProps {
   params: Promise<{ code: string }>
@@ -45,12 +46,15 @@ async function getSharedMaterial(
     return null
   }
 
-  return data
+  return parseSharedMaterial(data)
 }
 
 export async function generateMetadata({ params }: PageProps): Promise<Metadata> {
   const { code } = await params
-  const data = await getSharedMaterial(code)
+  const requestHeaders = await headers()
+  const requestIdentity = getRequestIdentifier(requestHeaders)
+  const identityHash = hashRequestIdentity(requestHeaders)
+  const data = await getSharedMaterial(code, requestIdentity, identityHash)
 
   if (!data) {
     return {
@@ -59,10 +63,7 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
     }
   }
 
-  const title = data.title || 'Shared Study Material'
-  const type = data.type === 'cards' ? 'Flashcards' : 'Reviewer'
-  const itemCount = data.items?.length || 0
-  const description = `Study ${title} - ${itemCount} ${type.toLowerCase()} on DeepTerm. Free AI-powered study tools.`
+  const { title, typeLabel: type, itemCount, description } = buildSharePageMeta(data)
   const url = `${siteConfig.url}/share/${code}`
 
   return {

--- a/src/components/GoogleSignIn.tsx
+++ b/src/components/GoogleSignIn.tsx
@@ -37,7 +37,8 @@ export default function GoogleSignIn() {
     }
   }
 
-  const handleCaptchaVerify = () => {
+  const handleCaptchaVerify = (token?: string) => {
+    if (!token) return
     setShowCaptcha(false)
     handleGoogleSignIn()
   }

--- a/src/components/ShareModal.tsx
+++ b/src/components/ShareModal.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { useState, useCallback } from "react"
+import { useState, useCallback, useEffect } from "react"
 import { X, Copy, Check, Link2, Loader2, RefreshCw } from "lucide-react"
 import type { MaterialShare, ShareMaterialType } from "@/lib/schemas/sharing"
 
@@ -33,10 +33,11 @@ export default function ShareModal({ isOpen, onClose, materialId, materialType, 
     }
   }, [materialId, materialType])
 
-  // Fetch on open
-  useState(() => {
-    if (isOpen) fetchShare()
-  })
+  useEffect(() => {
+    if (isOpen) {
+      void fetchShare()
+    }
+  }, [isOpen, fetchShare])
 
   const createShare = async () => {
     setLoading(true)

--- a/src/lib/auth/redirect.ts
+++ b/src/lib/auth/redirect.ts
@@ -1,0 +1,39 @@
+/**
+ * Validates that a redirect path is safe (relative, no open redirect).
+ * Returns the sanitized path or '/dashboard' if invalid.
+ */
+export function sanitizeRedirectPath(raw: string | null): string {
+  if (!raw) return '/dashboard'
+
+  let decoded: string
+  try {
+    decoded = decodeURIComponent(raw)
+  } catch {
+    return '/dashboard'
+  }
+
+  if (!decoded.startsWith('/') || decoded.startsWith('//')) {
+    return '/dashboard'
+  }
+
+  if (/[a-z]+:/i.test(decoded.replace(/^\//, ''))) {
+    return '/dashboard'
+  }
+
+  return decoded
+}
+
+/**
+ * Without a successful OAuth code exchange, never honor returnTo.
+ * Unauthenticated visitors should land on home rather than a protected route.
+ */
+export function resolveAuthCallbackPath(options: {
+  hasCode: boolean
+  exchangeFailed?: boolean
+  returnTo?: string | null
+}): string {
+  if (!options.hasCode || options.exchangeFailed) {
+    return '/'
+  }
+  return sanitizeRedirectPath(options.returnTo ?? null)
+}

--- a/src/lib/auth/trustedOrigins.ts
+++ b/src/lib/auth/trustedOrigins.ts
@@ -1,0 +1,23 @@
+export const TRUSTED_PRODUCTION_ORIGINS = [
+  'https://deepterm.tech',
+  'https://www.deepterm.tech',
+  'https://deepterm.app',
+  'https://www.deepterm.app',
+  'https://deepterm.vercel.app',
+] as const
+
+export const PRIMARY_ORIGIN = TRUSTED_PRODUCTION_ORIGINS[0]
+
+export function isTrustedOrigin(origin: string, isDev = false): boolean {
+  if ((TRUSTED_PRODUCTION_ORIGINS as readonly string[]).includes(origin)) {
+    return true
+  }
+  return isDev && origin.startsWith('http://localhost')
+}
+
+export function getTrustedOrigin(requestOrigin: string, isDev = false): string {
+  if (isTrustedOrigin(requestOrigin, isDev)) {
+    return requestOrigin
+  }
+  return PRIMARY_ORIGIN
+}

--- a/src/lib/schemas/sharing.ts
+++ b/src/lib/schemas/sharing.ts
@@ -11,6 +11,17 @@ export const ShareCodeCreateSchema = ShareCodeBaseSchema.min(8, 'Share code must
 export const ShareMaterialTypeSchema = z.enum(['flashcard_set', 'reviewer'])
 export type ShareMaterialType = z.infer<typeof ShareMaterialTypeSchema>
 
+export const ShareGetQuerySchema = z.object({
+  materialType: ShareMaterialTypeSchema,
+  materialId: z.string().uuid(),
+})
+
+export const SharePatchSchema = z.object({
+  shareId: z.string().uuid(),
+  isActive: z.boolean().optional(),
+  newCode: ShareCodeCreateSchema.optional(),
+})
+
 export const MaterialShareSchema = z.object({
   id: z.string().uuid(),
   share_code: z.string(),

--- a/src/lib/stores/activityStore.ts
+++ b/src/lib/stores/activityStore.ts
@@ -66,6 +66,15 @@ export const useActivityStore = create<ActivityStore>()((set, get) => ({
 
       if (calendarResult.error) throw calendarResult.error
 
+      if (statsResult.error) {
+        set({
+          activity: calendarResult.data || [],
+          loading: false,
+          lastFetched: Date.now(),
+        })
+        return
+      }
+
       set({
         activity: calendarResult.data || [],
         stats: statsResult.data,

--- a/src/lib/stores/materialsStore.ts
+++ b/src/lib/stores/materialsStore.ts
@@ -1,5 +1,6 @@
 import { create } from 'zustand'
 import type { MaterialItem, MaterialFilter } from '../schemas/materials'
+import { matchesMaterialFilter } from '@/utils/materialFilter'
 
 interface MaterialsState {
   items: MaterialItem[]
@@ -44,7 +45,7 @@ export const useMaterialsStore = create<MaterialsStore>()((set, get) => ({
     const { items, searchQuery, activeFilter } = get()
     return items.filter(item => {
       const matchesSearch = item.title.toLowerCase().includes(searchQuery.toLowerCase())
-      const matchesFilter = activeFilter === 'All' || item.type === activeFilter
+      const matchesFilter = matchesMaterialFilter(item.type, activeFilter)
       return matchesSearch && matchesFilter
     })
   },

--- a/src/lib/stores/pomodoroStore.ts
+++ b/src/lib/stores/pomodoroStore.ts
@@ -1,6 +1,7 @@
 import { create } from 'zustand'
 import type { TimerPhase, Task, PomodoroSettings } from '../schemas/pomodoro'
 import { logPomodoroSession, XP_REWARDS } from '@/services/activity'
+import { shouldLogPomodoroSession } from '@/utils/reviewerTerms'
 import { useXPStore } from './xpStore'
 import { useActivityStore } from './activityStore'
 
@@ -327,7 +328,7 @@ export const usePomodoroStore = create<PomodoroStore>()((set, get) => ({
     set({ isRunning: false });
 
     // Log session
-    if (sessionStartTime) {
+    if (sessionStartTime && shouldLogPomodoroSession(phase)) {
       const duration = phase === 'work' ? settings.workDuration
         : phase === 'shortBreak' ? settings.shortBreakDuration
           : settings.longBreakDuration;
@@ -343,8 +344,8 @@ export const usePomodoroStore = create<PomodoroStore>()((set, get) => ({
       } catch (error) {
         console.error('Failed to log session:', error);
       }
-      sessionStartTime = null;
     }
+    sessionStartTime = null;
 
     // Determine next phase and show prompt
     let nextPhase: TimerPhase;

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -1,13 +1,6 @@
 import { createServerClient } from '@supabase/ssr'
 import { NextResponse, type NextRequest } from 'next/server'
-
-// Allowed origins for CORS (SECURITY FIX - CWE-942)
-const ALLOWED_ORIGINS = [
-  'https://deepterm.app',
-  'https://www.deepterm.app',
-  'https://deepterm.vercel.app',
-  // Development origins are handled separately below
-]
+import { isTrustedOrigin } from '@/lib/auth/trustedOrigins'
 
 // Only allow 'unsafe-eval' in development (needed for Next.js HMR/React DevTools)
 const IS_DEV = process.env.NODE_ENV === 'development'
@@ -73,8 +66,7 @@ export async function proxy(request: NextRequest) {
   // CORS: Only allow trusted origins (SECURITY FIX)
   if (origin) {
     const isDev = process.env.NODE_ENV === 'development'
-    const isAllowed = ALLOWED_ORIGINS.includes(origin) ||
-      (isDev && origin.startsWith('http://localhost'))
+    const isAllowed = isTrustedOrigin(origin, isDev)
 
     if (isAllowed) {
       response.headers.set('Access-Control-Allow-Origin', origin)

--- a/src/services/geminiClient.ts
+++ b/src/services/geminiClient.ts
@@ -1,5 +1,6 @@
 import { GoogleGenAI, Type } from "@google/genai";
 import type { Schema } from "@google/genai";
+import { rotationOrder } from "@/utils/geminiRotation";
 
 // Re-export Type for use in API routes
 export { Type };
@@ -53,6 +54,7 @@ export interface GeminiRequestOptions {
     responseMimeType?: string;
     responseSchema?: Schema;
   };
+  preferredKeyIndex?: number;
 }
 
 export interface GeminiFileUploadOptions {
@@ -68,13 +70,16 @@ export async function generateContentWithRotation(
   }
 
   let lastError: Error | null = null;
+  const { preferredKeyIndex, ...generateOptions } = options;
+  const keyOrder = rotationOrder(API_KEYS.length, preferredKeyIndex ?? 0);
 
-  // First pass: try all keys
-  for (let i = 0; i < API_KEYS.length; i++) {
+  // First pass: try all keys, starting at the preferred index so file
+  // uploads and generation share the same Gemini API key.
+  for (const i of keyOrder) {
     try {
       console.log(`[GeminiClient] Attempting request with key ${i + 1}/${API_KEYS.length}`);
       const ai = new GoogleGenAI({ apiKey: API_KEYS[i] });
-      const response = await ai.models.generateContent(options);
+      const response = await ai.models.generateContent(generateOptions);
       console.log(`[GeminiClient] Success with key ${i + 1}`);
       return { text: response.text || "", keyIndex: i };
     } catch (error) {
@@ -89,16 +94,16 @@ export async function generateContentWithRotation(
     }
   }
 
-  // All keys exhausted, wait and retry from first key
+  // All keys exhausted, wait and retry from the preferred key
   console.log(`[GeminiClient] All keys exhausted. Waiting ${RETRY_DELAY_MS}ms before retry...`);
   await new Promise((resolve) => setTimeout(resolve, RETRY_DELAY_MS));
 
   // Second pass: retry all keys once more
-  for (let i = 0; i < API_KEYS.length; i++) {
+  for (const i of keyOrder) {
     try {
       console.log(`[GeminiClient] Retry attempt with key ${i + 1}/${API_KEYS.length}`);
       const ai = new GoogleGenAI({ apiKey: API_KEYS[i] });
-      const response = await ai.models.generateContent(options);
+      const response = await ai.models.generateContent(generateOptions);
       console.log(`[GeminiClient] Retry success with key ${i + 1}`);
       return { text: response.text || "", keyIndex: i };
     } catch (error) {

--- a/src/services/rateLimit.ts
+++ b/src/services/rateLimit.ts
@@ -8,6 +8,7 @@ interface RateLimitResult {
   resetAt: Date
   userId?: string
   authenticated: boolean
+  unavailable?: boolean
 }
 
 /**
@@ -62,7 +63,14 @@ export async function checkAndIncrementAIUsage(): Promise<RateLimitResult> {
 
   if (error) {
     console.error('Rate limit check error:', error)
-    return { allowed: false, remaining: 0, resetAt, userId: user.id, authenticated: true }
+    return {
+      allowed: false,
+      remaining: 0,
+      resetAt,
+      userId: user.id,
+      authenticated: true,
+      unavailable: true,
+    }
   }
 
   const result = data?.[0] || data

--- a/src/tests/api/generate-cards.integration.test.ts
+++ b/src/tests/api/generate-cards.integration.test.ts
@@ -144,6 +144,24 @@ describe('POST /api/generate-cards', () => {
       expect(body.resetAt).toBe(resetTime.toISOString())
     })
 
+    it('should return 503 when the rate limit service is unavailable', async () => {
+      mockCheckAndIncrementAIUsage.mockResolvedValueOnce({
+        allowed: false,
+        remaining: 0,
+        resetAt: new Date(),
+        userId: 'test-user-id',
+        authenticated: true,
+        unavailable: true,
+      })
+
+      const request = createFormDataRequest({ textContent: 'Test content' })
+      const response = await POST(request)
+
+      expect(response.status).toBe(503)
+      const body = await response.json()
+      expect(body.error).toBe('Rate limit service unavailable. Please try again.')
+    })
+
     it('should include remaining count in successful response', async () => {
       mockCheckAndIncrementAIUsage.mockResolvedValueOnce({ 
         allowed: true, 
@@ -170,6 +188,7 @@ describe('POST /api/generate-cards', () => {
       expect(response.status).toBe(400)
       const body = await response.json()
       expect(body.error).toBe('No file or text content provided')
+      expect(mockCheckAndIncrementAIUsage).not.toHaveBeenCalled()
     })
 
     it('should return 400 when text content exceeds maximum length', async () => {
@@ -205,6 +224,7 @@ describe('POST /api/generate-cards', () => {
       expect(response.status).toBe(400)
       const body = await response.json()
       expect(body.error).toBe('Unsupported file type. Only PDF files are allowed.')
+      expect(mockCheckAndIncrementAIUsage).not.toHaveBeenCalled()
     })
 
     it('should return 400 for files exceeding size limit', async () => {

--- a/src/tests/api/generate-cards.integration.test.ts
+++ b/src/tests/api/generate-cards.integration.test.ts
@@ -20,6 +20,7 @@ const mockCheckAndIncrementAIUsage = mock(() => Promise.resolve({
   resetAt: new Date(),
   userId: 'test-user-id',
   authenticated: true,
+  unavailable: false,
 }))
 
 const mockGenerateContentWithRotation = mock(() => Promise.resolve({
@@ -99,6 +100,7 @@ describe('POST /api/generate-cards', () => {
       resetAt: new Date(),
       userId: 'test-user-id',
       authenticated: true,
+      unavailable: false,
     })
     mockGenerateContentWithRotation.mockResolvedValue({
       text: mockGeminiResponse.text
@@ -132,6 +134,7 @@ describe('POST /api/generate-cards', () => {
         resetAt: resetTime,
         userId: 'test-user-id',
         authenticated: true,
+        unavailable: false,
       })
 
       const request = createFormDataRequest({ textContent: 'Test content' })
@@ -169,6 +172,7 @@ describe('POST /api/generate-cards', () => {
         resetAt: new Date(),
         userId: 'test-user-id',
         authenticated: true,
+        unavailable: false,
       })
 
       const request = createFormDataRequest({ textContent: 'Test content' })

--- a/src/tests/api/share.schema.test.ts
+++ b/src/tests/api/share.schema.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from 'bun:test'
+import { ShareGetQuerySchema, SharePatchSchema } from '@/lib/schemas/sharing'
+
+const VALID_UUID = '11111111-1111-4111-8111-111111111111'
+
+describe('share API schemas', () => {
+  it('rejects GET queries missing owner-safe identifiers', () => {
+    expect(ShareGetQuerySchema.safeParse({
+      materialType: 'flashcard_set',
+    }).success).toBe(false)
+    expect(ShareGetQuerySchema.safeParse({
+      materialType: 'cards',
+      materialId: VALID_UUID,
+    }).success).toBe(false)
+  })
+
+  it('accepts valid GET queries', () => {
+    expect(ShareGetQuerySchema.safeParse({
+      materialType: 'reviewer',
+      materialId: VALID_UUID,
+    }).success).toBe(true)
+  })
+
+  it('requires a UUID shareId on PATCH and validates custom codes', () => {
+    expect(SharePatchSchema.safeParse({ shareId: 'not-a-uuid' }).success).toBe(false)
+    expect(SharePatchSchema.safeParse({
+      shareId: VALID_UUID,
+      isActive: true,
+    }).success).toBe(true)
+    expect(SharePatchSchema.safeParse({
+      shareId: VALID_UUID,
+      newCode: 'short',
+    }).success).toBe(false)
+    expect(SharePatchSchema.safeParse({
+      shareId: VALID_UUID,
+      newCode: 'custom-code',
+    }).success).toBe(true)
+  })
+})

--- a/src/tests/auth/redirect.test.ts
+++ b/src/tests/auth/redirect.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from 'bun:test'
+import { getTrustedOrigin, isTrustedOrigin, PRIMARY_ORIGIN, TRUSTED_PRODUCTION_ORIGINS } from '@/lib/auth/trustedOrigins'
+import { resolveAuthCallbackPath, sanitizeRedirectPath } from '@/lib/auth/redirect'
+
+describe('trustedOrigins', () => {
+  it('includes the canonical production domain from siteConfig', () => {
+    expect(PRIMARY_ORIGIN).toBe('https://deepterm.tech')
+    expect(TRUSTED_PRODUCTION_ORIGINS).toContain('https://deepterm.tech')
+    expect(TRUSTED_PRODUCTION_ORIGINS).toContain('https://www.deepterm.tech')
+  })
+
+  it('accepts known production origins and localhost in development', () => {
+    expect(isTrustedOrigin('https://deepterm.tech')).toBe(true)
+    expect(isTrustedOrigin('https://deepterm.app')).toBe(true)
+    expect(isTrustedOrigin('https://evil.example')).toBe(false)
+    expect(isTrustedOrigin('http://localhost:3000', true)).toBe(true)
+    expect(isTrustedOrigin('http://localhost:3000', false)).toBe(false)
+  })
+
+  it('falls back to the canonical origin instead of an untrusted Host header', () => {
+    expect(getTrustedOrigin('https://evil.example')).toBe('https://deepterm.tech')
+    expect(getTrustedOrigin('https://deepterm.app')).toBe('https://deepterm.app')
+  })
+})
+
+describe('auth callback redirects', () => {
+  it('blocks open redirects', () => {
+    expect(sanitizeRedirectPath('https://evil.com')).toBe('/dashboard')
+    expect(sanitizeRedirectPath('//evil.com')).toBe('/dashboard')
+    expect(sanitizeRedirectPath('javascript:alert(1)')).toBe('/dashboard')
+    expect(sanitizeRedirectPath('/materials')).toBe('/materials')
+  })
+
+  it('sends visitors home when no OAuth code is present', () => {
+    expect(resolveAuthCallbackPath({ hasCode: false, returnTo: '/dashboard' })).toBe('/')
+    expect(resolveAuthCallbackPath({ hasCode: false })).toBe('/')
+  })
+
+  it('sends visitors home when code exchange fails', () => {
+    expect(resolveAuthCallbackPath({ hasCode: true, exchangeFailed: true, returnTo: '/materials' })).toBe('/')
+  })
+
+  it('honors a safe returnTo only after a successful code exchange', () => {
+    expect(resolveAuthCallbackPath({ hasCode: true, returnTo: '/materials' })).toBe('/materials')
+    expect(resolveAuthCallbackPath({ hasCode: true, returnTo: null })).toBe('/dashboard')
+  })
+})

--- a/src/tests/materialsStore.test.ts
+++ b/src/tests/materialsStore.test.ts
@@ -186,8 +186,8 @@ describe('materialsStore', () => {
       expect(filtered[0].type).toBe('Note')
     })
 
-    it('should filter by type Flashcards', () => {
-      useMaterialsStore.getState().setActiveFilter('Flashcards')
+    it('should treat Cards as an alias for Flashcards', () => {
+      useMaterialsStore.getState().setActiveFilter('Cards')
       const filtered = useMaterialsStore.getState().getFilteredItems()
       expect(filtered).toHaveLength(1)
       expect(filtered[0].type).toBe('Flashcards')

--- a/src/tests/services/geminiRotation.test.ts
+++ b/src/tests/services/geminiRotation.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from 'bun:test'
+import { rotationOrder } from '@/utils/geminiRotation'
+
+describe('gemini key rotation order', () => {
+  it('starts at the preferred key so file uploads and generation share the same key', () => {
+    expect(rotationOrder(3, 0)).toEqual([0, 1, 2])
+    expect(rotationOrder(3, 2)).toEqual([2, 0, 1])
+    expect(rotationOrder(1, 0)).toEqual([0])
+  })
+
+  it('wraps negative or oversized start indexes', () => {
+    expect(rotationOrder(4, 5)).toEqual([1, 2, 3, 0])
+    expect(rotationOrder(0, 0)).toEqual([])
+  })
+})

--- a/src/tests/services/shareRateLimit.test.ts
+++ b/src/tests/services/shareRateLimit.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it, beforeEach, afterEach } from 'bun:test'
+import { checkShareRateLimit, getRequestIdentifier } from '@/services/shareRateLimit'
+
+describe('shareRateLimit', () => {
+  beforeEach(() => {
+    globalThis.__deeptermShareRateLimitStore = {
+      lookup: new Map(),
+      copy: new Map(),
+    }
+  })
+
+  afterEach(() => {
+    globalThis.__deeptermShareRateLimitStore = undefined
+  })
+
+  it('builds an identifier from forwarded IP and user agent', () => {
+    const headers = new Headers({
+      'x-forwarded-for': '203.0.113.10, 10.0.0.1',
+      'user-agent': 'Mozilla/5.0 DeepTermTest',
+    })
+    expect(getRequestIdentifier(headers)).toBe('203.0.113.10|Mozilla/5.0 DeepTermTest')
+  })
+
+  it('allows requests under the lookup cap and then blocks', () => {
+    const first = checkShareRateLimit('lookup', 'ip|ua')
+    expect(first.allowed).toBe(true)
+    expect(first.remaining).toBe(59)
+
+    for (let i = 0; i < 59; i++) {
+      checkShareRateLimit('lookup', 'ip|ua')
+    }
+
+    const blocked = checkShareRateLimit('lookup', 'ip|ua')
+    expect(blocked.allowed).toBe(false)
+    expect(blocked.remaining).toBe(0)
+    expect(blocked.retryAfterSeconds).toBeGreaterThan(0)
+  })
+
+  it('isolates lookup and copy buckets', () => {
+    const lookup = checkShareRateLimit('lookup', 'same-id')
+    const copy = checkShareRateLimit('copy', 'same-id')
+    expect(lookup.remaining).toBe(59)
+    expect(copy.remaining).toBe(19)
+  })
+})

--- a/src/tests/utils/generateInput.test.ts
+++ b/src/tests/utils/generateInput.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'bun:test'
+import {
+  getPdfMimeTypeFromName,
+  isGenerateFileTooLarge,
+  MAX_CARDS_FILE_SIZE,
+  MAX_GENERATE_TEXT_LENGTH,
+  resolveGenerateMimeType,
+} from '@/utils/generateInput'
+
+describe('generateInput', () => {
+  it('only allows PDF mime types', () => {
+    expect(resolveGenerateMimeType({ name: 'notes.pdf', type: 'application/pdf' })).toBe('application/pdf')
+    expect(resolveGenerateMimeType({ name: 'notes.pdf', type: '' })).toBe('application/pdf')
+    expect(resolveGenerateMimeType({ name: 'notes.txt', type: 'text/plain' })).toBeNull()
+    expect(resolveGenerateMimeType({ name: 'notes.docx', type: 'application/vnd.openxmlformats-officedocument.wordprocessingml.document' })).toBeNull()
+    expect(resolveGenerateMimeType({ name: 'payload.exe', type: 'application/octet-stream' })).toBeNull()
+    expect(resolveGenerateMimeType({ name: 'photo.png', type: 'image/png' })).toBeNull()
+  })
+
+  it('rejects spoofed mime types even when the extension is pdf', () => {
+    expect(resolveGenerateMimeType({ name: 'notes.pdf', type: 'image/png' })).toBeNull()
+  })
+
+  it('resolves uppercase pdf extensions when mime type is missing', () => {
+    expect(getPdfMimeTypeFromName('Lecture.PDF')).toBe('application/pdf')
+    expect(getPdfMimeTypeFromName('file')).toBeNull()
+    expect(getPdfMimeTypeFromName('')).toBeNull()
+  })
+
+  it('enforces file size and text length limits used by the API', () => {
+    expect(isGenerateFileTooLarge(MAX_CARDS_FILE_SIZE + 1, MAX_CARDS_FILE_SIZE)).toBe(true)
+    expect(isGenerateFileTooLarge(MAX_CARDS_FILE_SIZE, MAX_CARDS_FILE_SIZE)).toBe(false)
+    expect(MAX_GENERATE_TEXT_LENGTH).toBe(100000)
+  })
+})

--- a/src/tests/utils/matchGame.test.ts
+++ b/src/tests/utils/matchGame.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from 'bun:test'
+import { createGameCards, selectMatchPairs, shuffleArray } from '@/utils/matchGame'
+
+describe('matchGame', () => {
+  it('does not always pick the first N cards from a larger set', () => {
+    const cards = Array.from({ length: 12 }, (_, i) => ({
+      id: `card-${i}`,
+      term: `Term ${i}`,
+      definition: `Def ${i}`,
+    }))
+
+    const selectedIds = new Set<string>()
+    for (let seed = 0; seed < 40; seed++) {
+      let i = seed
+      const random = () => {
+        i += 1
+        return (i * 17 % 100) / 100
+      }
+      selectMatchPairs(cards, 6, random).forEach((card) => selectedIds.add(card.id))
+    }
+
+    expect(selectedIds.has('card-11') || selectedIds.has('card-10') || selectedIds.has('card-9')).toBe(true)
+    expect(selectedIds.size).toBeGreaterThan(6)
+  })
+
+  it('returns all cards when the set is smaller than the pair count', () => {
+    const cards = [
+      { id: 'a', term: 'A', definition: '1' },
+      { id: 'b', term: 'B', definition: '2' },
+    ]
+    const selected = selectMatchPairs(cards, 6, () => 0.1)
+    expect(selected).toHaveLength(2)
+  })
+
+  it('creates shuffled term/definition pairs without duplicating pair ids', () => {
+    const game = createGameCards([
+      { id: '1', term: 'Cell', definition: 'Unit of life' },
+      { id: '2', term: 'DNA', definition: 'Genetic material' },
+    ], 6, () => 0.2)
+
+    expect(game).toHaveLength(4)
+    expect(game.filter((card) => card.type === 'term')).toHaveLength(2)
+    expect(game.filter((card) => card.type === 'definition')).toHaveLength(2)
+    expect(new Set(game.map((card) => card.id)).size).toBe(4)
+  })
+
+  it('shuffles without mutating the original array', () => {
+    const original = [1, 2, 3, 4]
+    const shuffled = shuffleArray(original, () => 0.9)
+    expect(original).toEqual([1, 2, 3, 4])
+    expect(shuffled).toHaveLength(4)
+  })
+})

--- a/src/tests/utils/materialFilter.test.ts
+++ b/src/tests/utils/materialFilter.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from 'bun:test'
+import { matchesMaterialFilter, selectMaterialSourceItems } from '@/utils/materialFilter'
+import type { MaterialItem } from '@/lib/schemas/materials'
+
+const flashcards: MaterialItem = {
+  id: '11111111-1111-1111-1111-111111111111',
+  title: 'Bio Cards',
+  type: 'Flashcards',
+  itemsCount: 10,
+  lastAccessed: '2024-01-01',
+}
+
+const reviewer: MaterialItem = {
+  id: '22222222-2222-2222-2222-222222222222',
+  title: 'History Reviewer',
+  type: 'Reviewer',
+  itemsCount: 8,
+  lastAccessed: '2024-01-02',
+}
+
+describe('materialFilter', () => {
+  it('treats the Cards UI filter as Flashcards', () => {
+    expect(matchesMaterialFilter('Flashcards', 'Cards')).toBe(true)
+    expect(matchesMaterialFilter('Reviewer', 'Cards')).toBe(false)
+  })
+
+  it('matches exact types and All', () => {
+    expect(matchesMaterialFilter('Reviewer', 'Reviewer')).toBe(true)
+    expect(matchesMaterialFilter('Flashcards', 'Reviewer')).toBe(false)
+    expect(matchesMaterialFilter('Flashcards', 'All')).toBe(true)
+    expect(matchesMaterialFilter('Reviewer', 'All')).toBe(true)
+  })
+
+  it('keeps an empty client list after init instead of falling back to stale server items', () => {
+    const initialItems = [flashcards, reviewer]
+    expect(selectMaterialSourceItems(false, [], initialItems)).toEqual(initialItems)
+    expect(selectMaterialSourceItems(true, [], initialItems)).toEqual([])
+  })
+})

--- a/src/tests/utils/practiceQuestions.test.ts
+++ b/src/tests/utils/practiceQuestions.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from 'bun:test'
+import {
+  buildFillBlankPrompt,
+  generateQuestionsFromCards,
+  gradePracticeAnswer,
+} from '@/utils/practiceQuestions'
+
+const cards = [
+  { id: '1', term: 'binary search tree', definition: 'A tree data structure with ordered children' },
+  { id: '2', term: 'stack', definition: 'Last in first out collection' },
+  { id: '3', term: 'queue', definition: 'First in first out collection' },
+  { id: '4', term: 'heap', definition: 'A complete binary tree used for priority' },
+]
+
+describe('practiceQuestions', () => {
+  it('uses the full definition as the fill-in-the-blank prompt', () => {
+    expect(buildFillBlankPrompt(cards[0].definition)).toBe(cards[0].definition)
+    expect(buildFillBlankPrompt(cards[0].definition)).not.toContain('_____')
+  })
+
+  it('grades fill-in-the-blank by exact term match, not first-word includes', () => {
+    expect(gradePracticeAnswer('fillBlank', 'binary search tree', 'binary search tree')).toBe(true)
+    expect(gradePracticeAnswer('fillBlank', 'BINARY SEARCH TREE', 'binary search tree')).toBe(true)
+    expect(gradePracticeAnswer('fillBlank', 'binary', 'binary search tree')).toBe(false)
+    expect(gradePracticeAnswer('fillBlank', 'I think binary is close', 'binary search tree')).toBe(false)
+  })
+
+  it('grades multiple choice and true/false with trimmed case-insensitive equality', () => {
+    expect(gradePracticeAnswer('multipleChoice', ' Stack ', 'stack')).toBe(true)
+    expect(gradePracticeAnswer('trueFalse', 'TRUE', 'true')).toBe(true)
+    expect(gradePracticeAnswer('trueFalse', 'false', 'true')).toBe(false)
+  })
+
+  it('builds fill-blank questions with the definition as the prompt and the term as the answer', () => {
+    const questions = generateQuestionsFromCards(cards, ['fillBlank'], 2, () => 0.1)
+    expect(questions.length).toBeGreaterThan(0)
+    expect(questions.every((q) => q.type === 'fillBlank')).toBe(true)
+    expect(questions.every((q) => !q.question.includes('_____'))).toBe(true)
+    expect(cards.map((c) => c.term)).toContain(questions[0].correctAnswer)
+  })
+})

--- a/src/tests/utils/reviewerTerms.test.ts
+++ b/src/tests/utils/reviewerTerms.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from 'bun:test'
+import {
+  buildReviewerTermInsert,
+  expectedWrittenAnswer,
+  promptLabelForFrontSide,
+  shouldLogPomodoroSession,
+} from '@/utils/reviewerTerms'
+
+describe('reviewer term insert payload', () => {
+  it('includes the required user_id so RLS insert policies succeed', () => {
+    expect(buildReviewerTermInsert('user-1', 'cat-1', 'Mitosis', 'Cell division')).toEqual({
+      user_id: 'user-1',
+      category_id: 'cat-1',
+      term: 'Mitosis',
+      definition: 'Cell division',
+    })
+  })
+})
+
+describe('learn mode written answers', () => {
+  const card = { term: 'stack', definition: 'LIFO collection' }
+
+  it('asks for the term when the front side is the definition', () => {
+    expect(expectedWrittenAnswer('definition', card)).toBe('stack')
+    expect(promptLabelForFrontSide('definition')).toBe('Definition')
+  })
+
+  it('asks for the definition when the front side is the term', () => {
+    expect(expectedWrittenAnswer('term', card)).toBe('LIFO collection')
+    expect(promptLabelForFrontSide('term')).toBe('Term')
+  })
+})
+
+describe('pomodoro session logging', () => {
+  it('only logs work phases so breaks do not award XP', () => {
+    expect(shouldLogPomodoroSession('work')).toBe(true)
+    expect(shouldLogPomodoroSession('shortBreak')).toBe(false)
+    expect(shouldLogPomodoroSession('longBreak')).toBe(false)
+  })
+})

--- a/src/tests/utils/shareMetadata.test.ts
+++ b/src/tests/utils/shareMetadata.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it } from 'bun:test'
+import { buildSharePageMeta, parseSharedMaterial } from '@/utils/shareMetadata'
+import type { SharedFlashcardSetData, SharedReviewerData } from '@/lib/schemas/sharing'
+
+const flashcardShare: SharedFlashcardSetData = {
+  type: 'flashcard_set',
+  share: { id: 'share-1', code: 'abc12345', created_at: '2024-01-01T00:00:00Z' },
+  material: { id: 'mat-1', title: 'Biology Cards', created_at: '2024-01-01T00:00:00Z' },
+  items: [
+    { id: '1', front: 'Cell', back: 'Basic unit of life' },
+    { id: '2', front: 'DNA', back: 'Genetic material' },
+  ],
+  owner: { name: 'Ada', avatar: null },
+}
+
+const reviewerShare: SharedReviewerData = {
+  type: 'reviewer',
+  share: { id: 'share-2', code: 'rev12345', created_at: '2024-01-01T00:00:00Z' },
+  material: {
+    id: 'mat-2',
+    title: 'History Reviewer',
+    extraction_mode: 'full',
+    created_at: '2024-01-01T00:00:00Z',
+  },
+  categories: [
+    {
+      id: 'cat-1',
+      name: 'WWII',
+      color: '#E0F2FE',
+      terms: [
+        { id: 't1', term: 'D-Day', definition: 'Allied invasion', examples: null, keywords: null },
+        { id: 't2', term: 'Blitz', definition: 'Air campaign', examples: null, keywords: null },
+      ],
+    },
+    {
+      id: 'cat-2',
+      name: 'Cold War',
+      color: '#FCE7F3',
+      terms: [
+        { id: 't3', term: 'NATO', definition: 'Alliance', examples: null, keywords: null },
+      ],
+    },
+  ],
+  owner: { name: 'Ada', avatar: null },
+}
+
+describe('shareMetadata', () => {
+  describe('parseSharedMaterial', () => {
+    it('accepts a valid flashcard_set RPC payload', () => {
+      expect(parseSharedMaterial(flashcardShare)?.type).toBe('flashcard_set')
+    })
+
+    it('accepts a valid reviewer RPC payload', () => {
+      expect(parseSharedMaterial(reviewerShare)?.type).toBe('reviewer')
+    })
+
+    it('rejects the legacy flat metadata shape that used data.title and type=cards', () => {
+      expect(parseSharedMaterial({
+        title: 'Biology Cards',
+        type: 'cards',
+        items: [{ term: 'Cell', definition: 'Basic unit of life' }],
+      })).toBeNull()
+    })
+  })
+
+  describe('buildSharePageMeta', () => {
+    it('uses material.title and flashcard_set type instead of data.title / cards', () => {
+      const meta = buildSharePageMeta(flashcardShare)
+      expect(meta.title).toBe('Biology Cards')
+      expect(meta.typeLabel).toBe('Flashcards')
+      expect(meta.itemCount).toBe(2)
+      expect(meta.description).toContain('2 flashcards')
+    })
+
+    it('counts reviewer terms across categories instead of data.items', () => {
+      const meta = buildSharePageMeta(reviewerShare)
+      expect(meta.title).toBe('History Reviewer')
+      expect(meta.typeLabel).toBe('Reviewer')
+      expect(meta.itemCount).toBe(3)
+      expect(meta.description).toContain('3 reviewer terms')
+    })
+
+    it('falls back to a generic title when material title is blank', () => {
+      const meta = buildSharePageMeta({
+        ...flashcardShare,
+        material: { ...flashcardShare.material, title: '   ' },
+      })
+      expect(meta.title).toBe('Shared Study Material')
+    })
+  })
+})

--- a/src/utils/geminiRotation.ts
+++ b/src/utils/geminiRotation.ts
@@ -1,0 +1,5 @@
+export function rotationOrder(keyCount: number, startIndex = 0): number[] {
+  if (keyCount <= 0) return []
+  const start = ((startIndex % keyCount) + keyCount) % keyCount
+  return Array.from({ length: keyCount }, (_, i) => (start + i) % keyCount)
+}

--- a/src/utils/generateInput.ts
+++ b/src/utils/generateInput.ts
@@ -1,0 +1,23 @@
+export const ALLOWED_GENERATE_MIME_TYPES = ['application/pdf'] as const
+export const MAX_CARDS_FILE_SIZE = 20 * 1024 * 1024
+export const MAX_REVIEWER_FILE_SIZE = 10 * 1024 * 1024
+export const MAX_GENERATE_TEXT_LENGTH = 100000
+
+export function getPdfMimeTypeFromName(filename: string): string | null {
+  const ext = filename.toLowerCase().split('.').pop()
+  if (!ext || ext === filename.toLowerCase()) return null
+  return ext === 'pdf' ? 'application/pdf' : null
+}
+
+export function resolveGenerateMimeType(file: { name: string; type?: string | null }): string | null {
+  const mimeType = file.type || getPdfMimeTypeFromName(file.name)
+  if (!mimeType) return null
+  if (!(ALLOWED_GENERATE_MIME_TYPES as readonly string[]).includes(mimeType)) {
+    return null
+  }
+  return mimeType
+}
+
+export function isGenerateFileTooLarge(fileSize: number, maxFileSize: number): boolean {
+  return fileSize > maxFileSize
+}

--- a/src/utils/matchGame.ts
+++ b/src/utils/matchGame.ts
@@ -1,0 +1,55 @@
+export function shuffleArray<T>(items: T[], random: () => number = Math.random): T[] {
+  const copy = [...items]
+  for (let i = copy.length - 1; i > 0; i--) {
+    const j = Math.floor(random() * (i + 1))
+    const current = copy[i]
+    copy[i] = copy[j]
+    copy[j] = current
+  }
+  return copy
+}
+
+export function selectMatchPairs<T>(data: T[], pairCount = 6, random: () => number = Math.random): T[] {
+  if (data.length <= pairCount) {
+    return shuffleArray(data, random)
+  }
+  return shuffleArray(data, random).slice(0, pairCount)
+}
+
+export interface MatchCardInput {
+  id: string
+  term: string
+  definition: string
+}
+
+export interface MatchCard {
+  id: string
+  content: string
+  type: 'term' | 'definition'
+  pairId: string
+  isMatched: boolean
+}
+
+export function createGameCards(data: MatchCardInput[], pairCount = 6, random: () => number = Math.random): MatchCard[] {
+  const selected = selectMatchPairs(data, pairCount, random)
+  const gameCards: MatchCard[] = []
+
+  selected.forEach((item) => {
+    gameCards.push({
+      id: `term-${item.id}`,
+      content: item.term,
+      type: 'term',
+      pairId: item.id,
+      isMatched: false,
+    })
+    gameCards.push({
+      id: `def-${item.id}`,
+      content: item.definition,
+      type: 'definition',
+      pairId: item.id,
+      isMatched: false,
+    })
+  })
+
+  return shuffleArray(gameCards, random)
+}

--- a/src/utils/materialFilter.ts
+++ b/src/utils/materialFilter.ts
@@ -1,0 +1,15 @@
+import type { MaterialFilter, MaterialItem } from '@/lib/schemas/materials'
+
+export function matchesMaterialFilter(itemType: MaterialItem['type'], activeFilter: MaterialFilter): boolean {
+  if (activeFilter === 'All') return true
+  if (activeFilter === 'Cards') return itemType === 'Flashcards'
+  return itemType === activeFilter
+}
+
+export function selectMaterialSourceItems<T>(
+  initialized: boolean,
+  items: T[],
+  initialItems: T[],
+): T[] {
+  return initialized ? items : initialItems
+}

--- a/src/utils/practiceQuestions.ts
+++ b/src/utils/practiceQuestions.ts
@@ -1,0 +1,89 @@
+export type QuestionType = 'multipleChoice' | 'trueFalse' | 'fillBlank'
+
+export interface PracticeCard {
+  id: string
+  term: string
+  definition: string
+}
+
+export interface PracticeQuestion {
+  id: string
+  type: QuestionType
+  question: string
+  correctAnswer: string
+  options?: string[]
+  tfDisplayedTerm?: string
+  tfIsCorrectPairing?: boolean
+  userAnswer?: string
+  isCorrect?: boolean
+}
+
+export function buildFillBlankPrompt(definition: string): string {
+  return definition.trim()
+}
+
+export function gradePracticeAnswer(
+  type: QuestionType,
+  userAnswer: string,
+  correctAnswer: string,
+): boolean {
+  const answer = userAnswer.toLowerCase().trim()
+  const expected = correctAnswer.toLowerCase().trim()
+  return answer === expected
+}
+
+export function generateQuestionsFromCards(
+  cards: PracticeCard[],
+  types: QuestionType[],
+  cardCount: number,
+  random: () => number = Math.random,
+): PracticeQuestion[] {
+  const questions: PracticeQuestion[] = []
+  const shuffled = [...cards].sort(() => random() - 0.5)
+  const selectedCards = shuffled.slice(0, cardCount)
+  const enabledTypes = types.length > 0 ? types : ['multipleChoice']
+
+  selectedCards.forEach((card, idx) => {
+    const type = enabledTypes[idx % enabledTypes.length]
+
+    if (type === 'trueFalse') {
+      const isCorrectPairing = random() > 0.5
+      const others = cards.filter((c) => c.id !== card.id)
+      const displayedTerm = isCorrectPairing || others.length === 0
+        ? card.term
+        : others[Math.floor(random() * others.length)].term
+
+      questions.push({
+        id: card.id,
+        type,
+        question: card.definition,
+        correctAnswer: isCorrectPairing ? 'true' : 'false',
+        tfDisplayedTerm: displayedTerm,
+        tfIsCorrectPairing: isCorrectPairing,
+      })
+      return
+    }
+
+    if (type === 'fillBlank') {
+      questions.push({
+        id: card.id,
+        type,
+        question: buildFillBlankPrompt(card.definition),
+        correctAnswer: card.term,
+      })
+      return
+    }
+
+    const others = cards.filter((c) => c.id !== card.id).map((c) => c.term)
+    const wrongOptions = others.sort(() => random() - 0.5).slice(0, 3)
+    questions.push({
+      id: card.id,
+      type: 'multipleChoice',
+      question: card.definition,
+      correctAnswer: card.term,
+      options: [...wrongOptions, card.term].sort(() => random() - 0.5),
+    })
+  })
+
+  return questions
+}

--- a/src/utils/reviewerTerms.ts
+++ b/src/utils/reviewerTerms.ts
@@ -1,0 +1,28 @@
+export function buildReviewerTermInsert(
+  userId: string,
+  categoryId: string,
+  term: string,
+  definition: string,
+) {
+  return {
+    user_id: userId,
+    category_id: categoryId,
+    term,
+    definition,
+  }
+}
+
+export function shouldLogPomodoroSession(phase: 'work' | 'shortBreak' | 'longBreak'): boolean {
+  return phase === 'work'
+}
+
+export function expectedWrittenAnswer(
+  frontSide: 'term' | 'definition',
+  card: { term: string; definition: string },
+): string {
+  return frontSide === 'definition' ? card.term : card.definition
+}
+
+export function promptLabelForFrontSide(frontSide: 'term' | 'definition'): 'Term' | 'Definition' {
+  return frontSide === 'definition' ? 'Definition' : 'Term'
+}

--- a/src/utils/shareMetadata.ts
+++ b/src/utils/shareMetadata.ts
@@ -1,0 +1,35 @@
+import { SharedMaterialDataSchema, type SharedMaterialData } from '@/lib/schemas/sharing'
+
+export interface SharePageMeta {
+  title: string
+  typeLabel: 'Flashcards' | 'Reviewer'
+  itemCount: number
+  description: string
+}
+
+export function parseSharedMaterial(data: unknown): SharedMaterialData | null {
+  const parsed = SharedMaterialDataSchema.safeParse(data)
+  return parsed.success ? parsed.data : null
+}
+
+export function buildSharePageMeta(data: SharedMaterialData): SharePageMeta {
+  const title = data.material.title?.trim() || 'Shared Study Material'
+
+  if (data.type === 'flashcard_set') {
+    const itemCount = data.items.length
+    return {
+      title,
+      typeLabel: 'Flashcards',
+      itemCount,
+      description: `Study ${title} - ${itemCount} flashcards on DeepTerm. Free AI-powered study tools.`,
+    }
+  }
+
+  const itemCount = data.categories.reduce((sum, category) => sum + category.terms.length, 0)
+  return {
+    title,
+    typeLabel: 'Reviewer',
+    itemCount,
+    description: `Study ${title} - ${itemCount} reviewer terms on DeepTerm. Free AI-powered study tools.`,
+  }
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Full-feature investigation of DeepTerm (flashcards, reviewers, study modes, sharing, AI generation, auth, pomodoro, account). This PR fixes the user-facing and security bugs that had a reliable reproduction path, and adds tests that lock in the corrected behavior.

## Problem / motivation

Several core flows were incorrect: shared flashcard OG metadata used the wrong RPC shape, the share modal never loaded existing links on the detail page, AI quota was burned on invalid requests, match mode always used the first six cards, learn mode showed a hardcoded title, and break pomodoro phases awarded XP.

## Changes made

- Share pages parse `get_shared_material` with Zod and build metadata from `material.title` / `flashcard_set` / category term counts
- Share modal fetches on open (`useEffect`)
- Share GET/PATCH validate query/body; POST existing-share lookup is scoped to `user_id`
- Generate-cards and generate-reviewer validate input **before** incrementing quota, whitelist PDF MIME types, start Gemini generation on the upload key, and return 503 when the rate-limit RPC is down
- Match mode shuffles before selecting pairs and captures elapsed time via a ref
- Practice fill-in-the-blank uses the full definition and exact-term grading
- Learn mode uses the set title and respects `frontSide` for written answers
- Reviewer term inserts include `user_id`
- Materials list initializes empty libraries and keeps deleted-empty state
- Auth callback does not honor `returnTo` without a successful code exchange
- CORS/OAuth trusted origins include `deepterm.tech`
- Pomodoro logs work sessions only
- Account cancel deletion re-reads server status

## Bugs fixed

- Share OG/Twitter titles showed “Shared Study Material” / “Reviewer” for flashcard sets
- Share modal on material detail never loaded an existing link
- Share POST could return another user’s share row
- Invalid AI requests consumed the daily quota
- Reviewer uploads accepted non-PDF `file.type` values
- PDF generation could fail when upload and generate used different Gemini keys
- Rate-limit RPC errors looked like “daily limit reached” (429)
- Match always used the first 6 cards; completion time could be stale
- Practice fill-blank prompts were garbled and grading was too loose
- Learn header was hardcoded to “DSA MIDTERMS”
- Adding a reviewer term omitted `user_id` (RLS insert failure)
- Deleting the last material could resurrect it from stale `initialItems`
- `Cards` filter in the materials store never matched flashcards
- `/auth/callback?returnTo=/dashboard` without a code redirected into the app
- `deepterm.tech` was missing from CORS/OAuth allowlists
- Break pomodoro phases awarded 15 XP
- Google sign-in proceeded when Turnstile returned an empty token

## Tests added

- `src/tests/utils/shareMetadata.test.ts`
- `src/tests/utils/matchGame.test.ts`
- `src/tests/utils/practiceQuestions.test.ts`
- `src/tests/utils/materialFilter.test.ts`
- `src/tests/utils/generateInput.test.ts`
- `src/tests/utils/reviewerTerms.test.ts`
- `src/tests/auth/redirect.test.ts`
- `src/tests/services/shareRateLimit.test.ts`
- `src/tests/services/geminiRotation.test.ts`
- `src/tests/api/share.schema.test.ts`
- Updates to generate-cards integration tests (quota not consumed on 400; 503 on unavailable)
- Materials store `Cards` filter coverage

## Verification performed

- `bun test` — 527 pass, 0 fail
- `bun run lint` — 0 errors; 2 pre-existing `window.location.href` warnings (account page, sidebar)
- `bunx tsc --noEmit` — clean
- `bun run build` — compiled successfully; TypeScript finished; 28/28 pages generated

## Potential risks

- Share pages now 404 if RPC JSON does not match `SharedMaterialDataSchema` (stricter than before; matches `schema.sql`)
- Zod UUID validation on share GET/PATCH is RFC 4122-strict (Postgres-generated UUIDs are fine)
- Pomodoro breaks no longer write `pomodoro_sessions` rows; existing RPC would still award XP if breaks were logged
- Gemini `preferredKeyIndex` changes rotation order for PDF flows only

## Remaining issues

- In-memory share rate limits remain per-instance (serverless)
- Client `addXP` plus `log_completed_activity` can still double-count mastered-card XP; left unchanged because the intended reward split is unclear
- Google OAuth still has no server-side Turnstile verification (UI now requires a token)
- Blog topics can stay stuck in `generating`; `finalize_account_deletions` is not in repo SQL
- Placeholder tests in `rateLimit.test.ts` / `generate-cards.test.ts` still do not import production code

## Review notes

- Prefer reviewing `src/utils/shareMetadata.ts`, `src/app/share/[code]/page.tsx`, and `src/app/api/generate-cards/route.ts` first
- `src/proxy.ts` in Next.js 16 is the request proxy (not dead middleware)
- Auth callback now defaults failed/missing-code visits to `/` instead of `/dashboard`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a0325b-60cc-7dbc-bd93-e8dc1be22228?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a0325b-60cc-7dbc-bd93-e8dc1be22228&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

