### PR TITLE
Harden CSRF, origins, CSP — RPC grants already live

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,131 @@
+# DeepTerm
+
+AI study app: notes/PDFs → flashcards, reviewers, practice tests.
+
+- Canonical origin: `https://deepterm.tech` (legacy: `deepterm.app`, `deepterm.vercel.app`)
+- Repo: `4regab/deepterm`
+- Live Supabase: `lopurzvtignkqyubqgtz` (`ap-southeast-1`)
+
+Stack: Next.js 16 App Router, React 19, TypeScript, Bun, Tailwind 4, Zustand, Zod, `@supabase/ssr`, Gemini, Cloudflare Turnstile, Vercel.
+
+`README.md` env names and some paths are stale. This file wins.
+
+## Commands
+
+```bash
+bun install
+bun run dev              # bun --bun next dev
+bun run build
+bun run lint
+bun test                 # bun:test, files under src/tests/
+bun test --watch
+bunx tsc --noEmit
+```
+
+No `middleware.ts`. Next 16 entry is `src/proxy.ts`.
+
+## Layout
+
+```
+src/app/(dashboard)/                 # auth-gated UI
+src/components/DashboardChrome.tsx   # client chrome (sidebar, padding)
+src/app/api/                         # Route Handlers
+src/app/auth/callback/               # OAuth code exchange
+src/config/supabase/                 # browser + server clients
+src/lib/auth/                        # origins, CSRF, session cache
+src/lib/supabase/                    # SQL notes — lag live DB
+src/services/                        # Gemini rotation, Turnstile, rate limit
+src/lib/stores/                      # Zustand
+src/proxy.ts                         # CSP nonce, CORS, session refresh, gates
+```
+
+Protected prefixes in `src/proxy.ts`: `/dashboard`, `/materials`, `/pomodoro`, `/practice`, `/reviewer`, `/account`, `/achievements`, `/api/generate-cards`, `/api/generate-reviewer`, `/api/share`.
+
+## Auth
+
+- Identity: `supabase.auth.getUser()`. Never `getSession()` for authorization.
+- RSC helper: `getSession()` in `src/lib/auth/session.ts` (React `cache()` wrapping `getUser()`).
+- Cookie client: `createServerSupabaseClient()` from `@/config/supabase/server`.
+- Env: `NEXT_PUBLIC_SUPABASE_URL`, `NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY`, `SUPABASE_SECRET_KEY`.
+- Soft-delete: `profiles.deleted_at` set → proxy allows `/`, `/auth`, `/account` only.
+- OAuth redirects: `getTrustedOrigin()` in `src/lib/auth/trustedOrigins.ts`. Never reflect `Host`.
+
+## Cookie-auth APIs (CSRF)
+
+Cookie Route Handlers must call `forbiddenUnlessSameOrigin(request)` (`src/lib/auth/assertSameOrigin.ts`).
+
+Wired: `/api/generate-cards`, `/api/generate-reviewer`, `/api/share`, `/api/share/copy`.
+
+Do **not** Origin-check cron. Cron is `Authorization: Bearer ${CRON_SECRET}`:
+
+- `GET /api/cron/generate-article`
+- `GET /api/cron/finalize-deletions`
+- `POST /api/blog/generate`
+
+Prod: missing Origin and Referer → 403. CORS is `/api/*` only via `isTrustedOrigin`.
+
+## Security invariants
+
+- CSP is per-request in `src/proxy.ts` (nonce). No static CSP in `next.config.ts`.
+- `frame-ancestors 'none'`, `object-src 'none'`, `upgrade-insecure-requests` in prod.
+- JSON-LD: `serializeJsonLd()` in `src/lib/seo.ts`.
+- Generate/share: `Cache-Control: private, no-store`.
+- AI usage writes only via RPC `check_and_increment_ai_usage`.
+- Share IDs: UUID + type.
+- `SUPABASE_SECRET_KEY` is server-only.
+
+## Database
+
+Live DB is ahead of `src/lib/supabase/*.sql`. Those files are notes, not a replay script.
+
+Already true in production:
+
+- RLS on every public table
+- SECURITY DEFINER uses `SET search_path = ''`
+- Internal helpers live in `private` (not in PostgREST)
+
+App RPC names (what TypeScript calls):
+
+- Public read: `get_published_posts`, `get_post_by_slug`, `get_category_post_counts`, `get_shared_material`
+- User: `add_xp`, `check_and_increment_ai_usage`, dashboard/stats/deletion self-service
+- Admin / cron: `finalize_account_deletions` (`service_role` only)
+
+`003_security_hardening.sql` is already applied. Do not re-run it blindly.
+
+New SQL: helpers in `private`; `search_path = ''`; grant EXECUTE explicitly; never `GRANT … TO PUBLIC`.
+
+Unlimited bypass: app still `select`s `unlimited_users`. `002` moved `check_user_is_unlimited` to `private` — do not expose it over REST.
+
+## AI / limits
+
+- 10 generations / user / day unless row in `unlimited_users`.
+- Keys: `GEMINI_API_KEY` plus `GEMINI_API_KEY_1`…`GEMINI_API_KEY_5`. Rotation: `src/services/geminiClient.ts` (not `src/config/gemini.ts`).
+- Turnstile optional. Hostname allowlist: `TURNSTILE_HOSTNAMES`.
+
+## Tests
+
+Bun test + `src/tests/setup.ts`. Prefer factories there.
+
+`fetch` mocks: `as unknown as typeof fetch` (`preconnect` exists on `typeof fetch`).
+
+## UI
+
+- Dashboard layout is a server wrapper; chrome stays in `DashboardChrome`.
+- React Compiler is on. Don’t add `useMemo` / `useCallback` unless measured.
+- Cache Components (`cacheComponents: true`) is **off**. Don’t flip it in a drive-by.
+
+## Git
+
+- Author: `4regab <4regab@gmail.com>`.
+- No `Co-authored-by`, Cursor, or “made with” trailers.
+- Don’t commit unless asked. Don’t force-push `main`.
+- Messages: `feat(security): …`, `fix(auth): …`.
+
+## Don’t
+
+- Don’t trust `auth.getSession()` or the request `Host` header.
+- Don’t widen CORS onto documents. Don’t set `frame-ancestors 'self'`.
+- Don’t call admin RPCs from the browser.
+- Don’t put Origin CSRF on Bearer cron routes.
+- Don’t “fix” live grants by replaying `001` / `002` SQL.
+- Don’t enable leaked-password protection via SQL — Auth dashboard only.

--- a/next.config.ts
+++ b/next.config.ts
@@ -78,6 +78,22 @@ const nextConfig: NextConfig = {
         source: '/:path*',
         headers: securityHeaders,
       },
+      {
+        source: '/api/generate-cards',
+        headers: [{ key: 'Cache-Control', value: 'private, no-store' }],
+      },
+      {
+        source: '/api/generate-reviewer',
+        headers: [{ key: 'Cache-Control', value: 'private, no-store' }],
+      },
+      {
+        source: '/api/share/:path*',
+        headers: [{ key: 'Cache-Control', value: 'private, no-store' }],
+      },
+      {
+        source: '/api/share',
+        headers: [{ key: 'Cache-Control', value: 'private, no-store' }],
+      },
     ];
   },
 };

--- a/src/app/(dashboard)/layout.tsx
+++ b/src/app/(dashboard)/layout.tsx
@@ -1,54 +1,9 @@
-"use client";
-
-import { Suspense } from "react";
-import { usePathname } from "next/navigation";
-import dynamic from "next/dynamic";
-import { useUIStore } from "@/lib/stores";
-import PomodoroNotification from "@/components/PomodoroNotification";
-import TaskReminderNotification from "@/components/TaskReminderNotification";
-
-// Dynamic import for Sidebar
-const Sidebar = dynamic(() => import("@/components/Sidebar"), {
-    ssr: false,
-    loading: () => <SidebarSkeleton />,
-});
-
-function SidebarSkeleton() {
-    return (
-        <aside className="fixed left-0 top-0 h-screen w-[64px] bg-[#f0f0ea] border-r border-[#171d2b]/10 hidden md:block" />
-    );
-}
+import DashboardChrome from "@/components/DashboardChrome";
 
 export default function DashboardLayout({
-    children,
+  children,
 }: {
-    children: React.ReactNode;
+  children: React.ReactNode;
 }) {
-    const pathname = usePathname();
-    const sidebarPinned = useUIStore((state) => state.sidebarPinned);
-
-    // Study mode pages - hide sidebar during active study
-    const isStudyMode = pathname?.includes("/materials/") && (
-        pathname?.includes("/flashcards") ||
-        pathname?.includes("/learn") ||
-        pathname?.includes("/practice") ||
-        pathname?.includes("/match")
-    );
-
-    return (
-        <div className="min-h-screen bg-[#f0f0ea]">
-            <PomodoroNotification />
-            <TaskReminderNotification />
-            {!isStudyMode && (
-                <Suspense fallback={<SidebarSkeleton />}>
-                    <Sidebar />
-                </Suspense>
-            )}
-            <main className={`${!isStudyMode ? (sidebarPinned ? "pl-0 md:pl-[220px]" : "pl-0 md:pl-[64px]") : ""} min-h-screen transition-all duration-300`}>
-                <div className={`w-full ${!isStudyMode ? "px-4 sm:px-6 lg:px-8 xl:px-10 pt-16 pb-4 sm:pt-6 sm:pb-6 lg:pt-8 lg:pb-8 md:py-6 lg:py-8" : "p-0"}`}>
-                    {children}
-                </div>
-            </main>
-        </div>
-    );
+  return <DashboardChrome>{children}</DashboardChrome>;
 }

--- a/src/app/api/generate-cards/route.ts
+++ b/src/app/api/generate-cards/route.ts
@@ -4,6 +4,7 @@ import { checkAndIncrementAIUsage } from "@/services/rateLimit";
 import { generateContentWithRotation, uploadFileWithRotation, getApiKeyCount, Type } from "@/services/geminiClient";
 import { verifyTurnstileToken } from "@/services/turnstile";
 import { z } from "zod";
+import { forbiddenUnlessSameOrigin } from "@/lib/auth/assertSameOrigin";
 
 // File size limits (in bytes)
 const MAX_FILE_SIZE = 20 * 1024 * 1024; // 20MB
@@ -38,6 +39,9 @@ const flashcardResponseSchema = {
 };
 
 export async function POST(request: NextRequest) {
+  const csrf = forbiddenUnlessSameOrigin(request);
+  if (csrf) return csrf;
+
   if (getApiKeyCount() === 0) {
     return NextResponse.json({ error: "No Gemini API keys configured" }, { status: 500 });
   }

--- a/src/app/api/generate-reviewer/route.ts
+++ b/src/app/api/generate-reviewer/route.ts
@@ -3,6 +3,7 @@ import { FileState } from "@google/genai";
 import { checkAndIncrementAIUsage } from "@/services/rateLimit";
 import { generateContentWithRotation, uploadFileWithRotation, getApiKeyCount, Type } from "@/services/geminiClient";
 import { verifyTurnstileToken } from "@/services/turnstile";
+import { forbiddenUnlessSameOrigin } from "@/lib/auth/assertSameOrigin";
 
 // File size limits (in bytes)
 const MAX_FILE_SIZE = 10 * 1024 * 1024; // 10MB - reduced for faster processing
@@ -75,6 +76,9 @@ const reviewerResponseSchema = {
 };
 
 export async function POST(request: NextRequest) {
+    const csrf = forbiddenUnlessSameOrigin(request);
+    if (csrf) return csrf;
+
     if (getApiKeyCount() === 0) {
         return NextResponse.json({ error: "No Gemini API keys configured" }, { status: 500 });
     }

--- a/src/app/api/share/copy/route.ts
+++ b/src/app/api/share/copy/route.ts
@@ -5,6 +5,7 @@ import { checkShareRateLimit, getRequestIdentifier } from '@/services/shareRateL
 import { hashRequestIdentity } from '@/lib/auth/requestIdentity'
 import { buildReviewerInsertPayloads } from '@/utils/reviewerBatch'
 import { z } from 'zod'
+import { forbiddenUnlessSameOrigin } from '@/lib/auth/assertSameOrigin'
 
 const CopySharedMaterialSchema = z.object({
   shareCode: ShareCodeSchema,
@@ -12,6 +13,9 @@ const CopySharedMaterialSchema = z.object({
 
 // POST - Copy shared material to user's collection
 export async function POST(request: NextRequest) {
+  const csrf = forbiddenUnlessSameOrigin(request)
+  if (csrf) return csrf
+
   const supabase = await createServerSupabaseClient()
   const { data: { user } } = await supabase.auth.getUser()
   

--- a/src/app/api/share/route.ts
+++ b/src/app/api/share/route.ts
@@ -1,7 +1,13 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { createServerSupabaseClient } from '@/config/supabase/server'
 import { ShareCodeCreateSchema, ShareMaterialTypeSchema } from '@/lib/schemas/sharing'
+import { forbiddenUnlessSameOrigin } from '@/lib/auth/assertSameOrigin'
 import { z } from 'zod'
+
+const ShareLookupSchema = z.object({
+  materialType: ShareMaterialTypeSchema,
+  materialId: z.string().uuid(),
+})
 
 const SHARE_CODE_ALPHABET = 'abcdefghijklmnopqrstuvwxyz0123456789'
 const DEFAULT_SHARE_CODE_LENGTH = 16
@@ -60,6 +66,9 @@ async function generateUniqueShareCode(
 
 // GET - Get share info for a material
 export async function GET(request: NextRequest) {
+  const csrf = forbiddenUnlessSameOrigin(request)
+  if (csrf) return csrf
+
   const supabase = await createServerSupabaseClient()
   const { data: { user } } = await supabase.auth.getUser()
 
@@ -68,12 +77,16 @@ export async function GET(request: NextRequest) {
   }
 
   const { searchParams } = new URL(request.url)
-  const materialType = searchParams.get('materialType')
-  const materialId = searchParams.get('materialId')
+  const parsedQuery = ShareLookupSchema.safeParse({
+    materialType: searchParams.get('materialType'),
+    materialId: searchParams.get('materialId'),
+  })
 
-  if (!materialType || !materialId) {
-    return NextResponse.json({ error: 'Missing parameters' }, { status: 400 })
+  if (!parsedQuery.success) {
+    return NextResponse.json({ error: 'Invalid parameters' }, { status: 400 })
   }
+
+  const { materialType, materialId } = parsedQuery.data
 
   // Optimized: only select needed columns
   const { data: share } = await supabase
@@ -89,6 +102,9 @@ export async function GET(request: NextRequest) {
 
 // POST - Create or update share
 export async function POST(request: NextRequest) {
+  const csrf = forbiddenUnlessSameOrigin(request)
+  if (csrf) return csrf
+
   const supabase = await createServerSupabaseClient()
   const { data: { user } } = await supabase.auth.getUser()
 
@@ -191,6 +207,9 @@ export async function POST(request: NextRequest) {
 
 // PATCH - Update share (toggle active, change code)
 export async function PATCH(request: NextRequest) {
+  const csrf = forbiddenUnlessSameOrigin(request)
+  if (csrf) return csrf
+
   const supabase = await createServerSupabaseClient()
   const { data: { user } } = await supabase.auth.getUser()
 
@@ -199,9 +218,11 @@ export async function PATCH(request: NextRequest) {
   }
 
   const body = await request.json()
-  const { shareId, isActive, newCode } = body
+  const shareId = z.string().uuid().safeParse(body?.shareId)
+  const isActive = body?.isActive
+  const newCode = body?.newCode
 
-  if (!shareId) {
+  if (!shareId.success) {
     return NextResponse.json({ error: 'Missing shareId' }, { status: 400 })
   }
 
@@ -222,7 +243,7 @@ export async function PATCH(request: NextRequest) {
       .from('material_shares')
       .select('id')
       .eq('share_code', newCode)
-      .neq('id', shareId)
+      .neq('id', shareId.data)
       .maybeSingle()
 
     if (codeExistsError) {
@@ -240,7 +261,7 @@ export async function PATCH(request: NextRequest) {
   const { data: share, error } = await supabase
     .from('material_shares')
     .update(updates)
-    .eq('id', shareId)
+    .eq('id', shareId.data)
     .eq('user_id', user.id)
     .select()
     .single()
@@ -254,6 +275,9 @@ export async function PATCH(request: NextRequest) {
 
 // DELETE - Remove share
 export async function DELETE(request: NextRequest) {
+  const csrf = forbiddenUnlessSameOrigin(request)
+  if (csrf) return csrf
+
   const supabase = await createServerSupabaseClient()
   const { data: { user } } = await supabase.auth.getUser()
 
@@ -262,16 +286,16 @@ export async function DELETE(request: NextRequest) {
   }
 
   const { searchParams } = new URL(request.url)
-  const shareId = searchParams.get('shareId')
+  const shareId = z.string().uuid().safeParse(searchParams.get('shareId'))
 
-  if (!shareId) {
+  if (!shareId.success) {
     return NextResponse.json({ error: 'Missing shareId' }, { status: 400 })
   }
 
   const { error } = await supabase
     .from('material_shares')
     .delete()
-    .eq('id', shareId)
+    .eq('id', shareId.data)
     .eq('user_id', user.id)
 
   if (error) {

--- a/src/app/auth/callback/route.ts
+++ b/src/app/auth/callback/route.ts
@@ -1,32 +1,6 @@
 import { createServerSupabaseClient } from '@/config/supabase/server'
 import { NextResponse } from 'next/server'
-
-// Trusted origins — prevents host header injection (CWE-644)
-const TRUSTED_ORIGINS = [
-  'https://deepterm.app',
-  'https://www.deepterm.app',
-  'https://deepterm.vercel.app',
-]
-
-/**
- * Returns a trusted origin, falling back to the primary domain.
- * Prevents host header injection by ignoring untrusted request origins.
- */
-function getTrustedOrigin(requestUrl: URL): string {
-  const requestOrigin = requestUrl.origin
-
-  // In development, allow localhost
-  if (process.env.NODE_ENV === 'development' && requestOrigin.startsWith('http://localhost')) {
-    return requestOrigin
-  }
-
-  if (TRUSTED_ORIGINS.includes(requestOrigin)) {
-    return requestOrigin
-  }
-
-  // Fallback to primary domain — never trust an unknown Host header
-  return TRUSTED_ORIGINS[0]
-}
+import { getTrustedOrigin } from '@/lib/auth/trustedOrigins'
 
 /**
  * Validates that a redirect path is safe (relative, no open redirect).

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -8,6 +8,7 @@ import {
   generateWebsiteJsonLd,
   generateOrganizationJsonLd,
   generateSoftwareAppJsonLd,
+  serializeJsonLd,
 } from "@/lib/seo";
 import { PostHogProvider } from "@/components/PostHogProvider";
 
@@ -53,17 +54,17 @@ export default async function RootLayout({
         <script
           nonce={nonce}
           type="application/ld+json"
-          dangerouslySetInnerHTML={{ __html: JSON.stringify(websiteJsonLd) }}
+          dangerouslySetInnerHTML={{ __html: serializeJsonLd(websiteJsonLd) }}
         />
         <script
           nonce={nonce}
           type="application/ld+json"
-          dangerouslySetInnerHTML={{ __html: JSON.stringify(organizationJsonLd) }}
+          dangerouslySetInnerHTML={{ __html: serializeJsonLd(organizationJsonLd) }}
         />
         <script
           nonce={nonce}
           type="application/ld+json"
-          dangerouslySetInnerHTML={{ __html: JSON.stringify(softwareAppJsonLd) }}
+          dangerouslySetInnerHTML={{ __html: serializeJsonLd(softwareAppJsonLd) }}
         />
       </head>
       <body suppressHydrationWarning>

--- a/src/app/llms.txt/route.ts
+++ b/src/app/llms.txt/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from 'next/server'
 import { getPublishedPosts, getCategoriesWithCounts } from '@/lib/blog'
+import { siteConfig } from '@/lib/seo'
 
 export const revalidate = 3600 // Revalidate every hour
 
@@ -9,7 +10,7 @@ export async function GET() {
         getCategoriesWithCounts(),
     ])
 
-    const baseUrl = 'https://deepterm.tech'
+    const baseUrl = siteConfig.url
 
     const categoryLines = categories
         .filter((c) => c.post_count > 0)
@@ -55,7 +56,7 @@ export async function GET() {
         '## Optional',
         '',
         '- [GitHub Repository](https://github.com/4regab/deepterm): Open-source codebase',
-        '- [Donate](https://ko-fi.com/deepterm): Support development on Ko-fi',
+        '- [Donate](https://ko-fi.com/4regab): Support development on Ko-fi',
         '',
     ]
 

--- a/src/components/DashboardChrome.tsx
+++ b/src/components/DashboardChrome.tsx
@@ -1,0 +1,56 @@
+"use client";
+
+import { Suspense } from "react";
+import { usePathname } from "next/navigation";
+import dynamic from "next/dynamic";
+import { useUIStore } from "@/lib/stores";
+import PomodoroNotification from "@/components/PomodoroNotification";
+import TaskReminderNotification from "@/components/TaskReminderNotification";
+
+const Sidebar = dynamic(() => import("@/components/Sidebar"), {
+  ssr: false,
+  loading: () => <SidebarSkeleton />,
+});
+
+function SidebarSkeleton() {
+  return (
+    <aside className="fixed left-0 top-0 h-screen w-[64px] bg-[#f0f0ea] border-r border-[#171d2b]/10 hidden md:block" />
+  );
+}
+
+export default function DashboardChrome({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  const pathname = usePathname();
+  const sidebarPinned = useUIStore((state) => state.sidebarPinned);
+
+  const isStudyMode =
+    pathname?.includes("/materials/") &&
+    (pathname?.includes("/flashcards") ||
+      pathname?.includes("/learn") ||
+      pathname?.includes("/practice") ||
+      pathname?.includes("/match"));
+
+  return (
+    <div className="min-h-screen bg-[#f0f0ea]">
+      <PomodoroNotification />
+      <TaskReminderNotification />
+      {!isStudyMode && (
+        <Suspense fallback={<SidebarSkeleton />}>
+          <Sidebar />
+        </Suspense>
+      )}
+      <main
+        className={`${!isStudyMode ? (sidebarPinned ? "pl-0 md:pl-[220px]" : "pl-0 md:pl-[64px]") : ""} min-h-screen transition-all duration-300`}
+      >
+        <div
+          className={`w-full ${!isStudyMode ? "px-4 sm:px-6 lg:px-8 xl:px-10 pt-16 pb-4 sm:pt-6 sm:pb-6 lg:pt-8 lg:pb-8 md:py-6 lg:py-8" : "p-0"}`}
+        >
+          {children}
+        </div>
+      </main>
+    </div>
+  );
+}

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -1,5 +1,3 @@
-"use client";
-
 import Link from "next/link";
 
 const imgLogo = "/assets/logo.svg";
@@ -49,7 +47,7 @@ export default function Footer() {
           <div>
             <h4 className="font-sora text-[13px] sm:text-[14px] text-[#171d2b] mb-2 sm:mb-3">Connect</h4>
             <ul className="flex flex-col gap-1.5 sm:gap-2">
-              <li><a href="https://ko-fi.com/deepterm" target="_blank" rel="noopener noreferrer" className="font-sans text-[12px] sm:text-[13px] text-[#171d2b]/60 hover:text-[#171d2b] transition-colors">Donate</a></li>
+              <li><a href="https://ko-fi.com/4regab" target="_blank" rel="noopener noreferrer" className="font-sans text-[12px] sm:text-[13px] text-[#171d2b]/60 hover:text-[#171d2b] transition-colors">Donate</a></li>
               <li><a href="https://github.com/4regab/deepterm" target="_blank" rel="noopener noreferrer" className="font-sans text-[12px] sm:text-[13px] text-[#171d2b]/60 hover:text-[#171d2b] transition-colors">GitHub</a></li>
               <li><a href="mailto:deeptermai@gmail.com" className="font-sans text-[12px] sm:text-[13px] text-[#171d2b]/60 hover:text-[#171d2b] transition-colors">Email</a></li>
             </ul>
@@ -59,10 +57,10 @@ export default function Footer() {
         {/* Bottom Bar */}
         <div className="flex flex-col sm:flex-row items-center justify-between pt-4 sm:pt-6 border-t border-[#171d2b]/10 gap-3 sm:gap-4">
           <p className="font-sans text-[11px] sm:text-[12px] text-[#171d2b]/50">
-            © 2025 DeepTerm. All rights reserved.
+            © {new Date().getFullYear()} DeepTerm. All rights reserved.
           </p>
           <div className="flex items-center gap-4">
-            <a href="https://ko-fi.com/deepterm" target="_blank" rel="noopener noreferrer" className="text-[#171d2b]/50 hover:text-[#171d2b] transition-colors" aria-label="Ko-fi">
+            <a href="https://ko-fi.com/4regab" target="_blank" rel="noopener noreferrer" className="text-[#171d2b]/50 hover:text-[#171d2b] transition-colors" aria-label="Ko-fi">
               <svg className="w-4 h-4 sm:w-5 sm:h-5" fill="currentColor" viewBox="0 0 24 24"><path d="M23.881 8.948c-.773-4.085-4.859-4.593-4.859-4.593H.723c-.604 0-.679.798-.679.798s-.082 7.324-.022 11.822c.164 2.424 2.586 2.672 2.586 2.672s8.267-.023 11.966-.049c2.438-.426 2.683-2.566 2.658-3.734 4.352.24 7.422-2.831 6.649-6.916zm-11.062 3.511c-1.246 1.453-4.011 3.976-4.011 3.976s-.121.119-.31.023c-.076-.057-.108-.09-.108-.09-.443-.441-3.368-3.049-4.034-3.954-.709-.965-1.041-2.7-.091-3.71.951-1.01 3.005-1.086 4.363.407 0 0 1.565-1.782 3.468-.963 1.904.82 1.832 3.011.723 4.311zm6.173.478c-.928.116-1.682.028-1.682.028V7.284h1.77s1.971.551 1.971 2.638c0 1.913-.985 2.667-2.059 3.015z" /></svg>
             </a>
             <a href="https://github.com/4regab/deepterm" target="_blank" rel="noopener noreferrer" className="text-[#171d2b]/50 hover:text-[#171d2b] transition-colors" aria-label="GitHub">

--- a/src/lib/auth/assertSameOrigin.ts
+++ b/src/lib/auth/assertSameOrigin.ts
@@ -1,0 +1,47 @@
+import { NextResponse } from 'next/server'
+import { isTrustedOrigin } from './trustedOrigins'
+
+const NO_STORE = { 'Cache-Control': 'private, no-store' }
+
+function forbidden(): NextResponse {
+  return NextResponse.json(
+    { error: 'Forbidden' },
+    { status: 403, headers: NO_STORE },
+  )
+}
+
+/**
+ * CSRF defense for cookie-authenticated Route Handlers.
+ * Server Actions already compare Origin to Host; Route Handlers do not.
+ */
+export function forbiddenUnlessSameOrigin(request: Request): NextResponse | null {
+  const origin = request.headers.get('origin')
+  if (origin) {
+    return isTrustedOrigin(origin) ? null : forbidden()
+  }
+
+  const referer = request.headers.get('referer')
+  if (referer) {
+    try {
+      if (isTrustedOrigin(new URL(referer).origin)) return null
+    } catch {
+      return forbidden()
+    }
+    return forbidden()
+  }
+
+  if (process.env.NODE_ENV === 'production') {
+    return forbidden()
+  }
+  return null
+}
+
+export function jsonNoStore(
+  body: unknown,
+  init?: { status?: number },
+): NextResponse {
+  return NextResponse.json(body, {
+    status: init?.status ?? 200,
+    headers: NO_STORE,
+  })
+}

--- a/src/lib/auth/trustedOrigins.ts
+++ b/src/lib/auth/trustedOrigins.ts
@@ -1,0 +1,37 @@
+/**
+ * Single allowlist for Origin/Host checks (CORS, CSRF, OAuth redirects).
+ * Production canonical host is deepterm.tech; .app and vercel.app are legacy.
+ */
+export const CANONICAL_ORIGIN = 'https://deepterm.tech'
+
+export const TRUSTED_ORIGINS = [
+  CANONICAL_ORIGIN,
+  'https://www.deepterm.tech',
+  'https://deepterm.app',
+  'https://www.deepterm.app',
+  'https://deepterm.vercel.app',
+] as const
+
+export function isLocalDevOrigin(origin: string): boolean {
+  return (
+    origin.startsWith('http://localhost:') ||
+    origin.startsWith('http://127.0.0.1:')
+  )
+}
+
+export function isTrustedOrigin(origin: string | null | undefined): boolean {
+  if (!origin) return false
+  if ((TRUSTED_ORIGINS as readonly string[]).includes(origin)) return true
+  if (process.env.NODE_ENV === 'development' && isLocalDevOrigin(origin)) {
+    return true
+  }
+  return false
+}
+
+/** Never reflect the request Host header for redirects. */
+export function getTrustedOrigin(requestUrl: URL): string {
+  if (isTrustedOrigin(requestUrl.origin)) {
+    return requestUrl.origin
+  }
+  return CANONICAL_ORIGIN
+}

--- a/src/lib/seo.ts
+++ b/src/lib/seo.ts
@@ -1,5 +1,9 @@
 import { Metadata } from 'next'
 
+export function serializeJsonLd(data: unknown): string {
+  return JSON.stringify(data).replace(/</g, '\\u003c')
+}
+
 export const siteConfig = {
   name: 'DeepTerm',
   description: 'AI-powered study companion that transforms any material into flashcards, reviewers, and practice tests. Free alternative to Quizlet and Gizmo.',

--- a/src/lib/supabase/001_blog_schema.sql
+++ b/src/lib/supabase/001_blog_schema.sql
@@ -164,7 +164,7 @@ BEGIN
   LIMIT p_limit
   OFFSET p_offset;
 END;
-$$ LANGUAGE plpgsql SECURITY DEFINER;
+$$ LANGUAGE plpgsql SECURITY DEFINER SET search_path = public;
 
 
 -- 8. Function to get single post by slug
@@ -209,7 +209,7 @@ BEGIN
   LEFT JOIN blog_categories bc ON bp.category_id = bc.id
   WHERE bp.slug = p_slug AND bp.status = 'published';
 END;
-$$ LANGUAGE plpgsql SECURITY DEFINER;
+$$ LANGUAGE plpgsql SECURITY DEFINER SET search_path = public;
 
 -- 9. Function to get next topic from queue
 CREATE OR REPLACE FUNCTION get_next_topic_for_generation()
@@ -254,7 +254,10 @@ BEGIN
   LEFT JOIN blog_categories bc ON tq.category_id = bc.id
   WHERE tq.id = v_topic_id;
 END;
-$$ LANGUAGE plpgsql SECURITY DEFINER;
+$$ LANGUAGE plpgsql SECURITY DEFINER SET search_path = public;
+
+REVOKE ALL ON FUNCTION get_next_topic_for_generation() FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION get_next_topic_for_generation() TO service_role;
 
 -- 10. Function to get post count by category
 CREATE OR REPLACE FUNCTION get_category_post_counts()
@@ -276,4 +279,4 @@ BEGIN
   GROUP BY bc.id, bc.slug, bc.name, bc.description
   ORDER BY bc.name;
 END;
-$$ LANGUAGE plpgsql SECURITY DEFINER;
+$$ LANGUAGE plpgsql SECURITY DEFINER SET search_path = public;

--- a/src/lib/supabase/003_security_hardening.sql
+++ b/src/lib/supabase/003_security_hardening.sql
@@ -1,0 +1,50 @@
+-- Applied remotely via Supabase MCP (project lopurzvtignkqyubqgtz).
+-- Do not re-run blindly; these grants already exist in production.
+--
+-- 1) revoke_anon_execute_on_user_rpcs
+--    SECURITY DEFINER functions:
+--      private.*  -> service_role only
+--      public blog/share reads -> anon + authenticated + service_role
+--      remaining public RPCs -> authenticated + service_role
+-- 2) revoke_authenticated_from_admin_rpcs
+--      admin_cancel_account_deletion, admin_reset_ai_usage,
+--      finalize_account_deletions -> service_role only
+--
+-- The live database already had SET search_path = '' on SECURITY DEFINER
+-- functions and RLS enabled on every public table.
+
+do $$
+declare
+  fn record;
+  public_read text[] := array[
+    'get_published_posts',
+    'get_post_by_slug',
+    'get_category_post_counts',
+    'get_shared_material'
+  ];
+  admin_only text[] := array[
+    'admin_cancel_account_deletion',
+    'admin_reset_ai_usage',
+    'finalize_account_deletions'
+  ];
+begin
+  for fn in
+    select p.oid::regprocedure as sig, p.proname, n.nspname
+    from pg_proc p
+    join pg_namespace n on n.oid = p.pronamespace
+    where n.nspname in ('public', 'private')
+      and p.prosecdef
+  loop
+    execute format('revoke all on function %s from public', fn.sig);
+
+    if fn.nspname = 'private' or fn.proname = any(admin_only) then
+      execute format('revoke all on function %s from anon, authenticated', fn.sig);
+      execute format('grant execute on function %s to service_role', fn.sig);
+    elsif fn.proname = any(public_read) then
+      execute format('grant execute on function %s to anon, authenticated, service_role', fn.sig);
+    else
+      execute format('revoke all on function %s from anon', fn.sig);
+      execute format('grant execute on function %s to authenticated, service_role', fn.sig);
+    end if;
+  end loop;
+end $$;

--- a/src/lib/supabase/supabase-rls-policies.sql
+++ b/src/lib/supabase/supabase-rls-policies.sql
@@ -443,7 +443,7 @@ BEGIN
     WHERE ms.share_code = p_share_code 
     AND ms.is_active = true;
 END;
-$$ LANGUAGE plpgsql SECURITY DEFINER;
+$$ LANGUAGE plpgsql SECURITY DEFINER SET search_path = public;
 
 -- Get shared flashcard set by share code (secure access)
 CREATE OR REPLACE FUNCTION get_shared_flashcard_set(p_share_code text)
@@ -468,7 +468,7 @@ BEGIN
     AND ms.is_active = true
     AND ms.material_type = 'flashcard_set';
 END;
-$$ LANGUAGE plpgsql SECURITY DEFINER;
+$$ LANGUAGE plpgsql SECURITY DEFINER SET search_path = public;
 
 -- Get shared flashcards by share code (secure access)
 -- Note: Does NOT expose user study progress (status, last_reviewed)
@@ -493,7 +493,7 @@ BEGIN
     AND ms.is_active = true
     AND ms.material_type = 'flashcard_set';
 END;
-$$ LANGUAGE plpgsql SECURITY DEFINER;
+$$ LANGUAGE plpgsql SECURITY DEFINER SET search_path = public;
 
 -- Grant execute permissions to anonymous and authenticated users
 GRANT EXECUTE ON FUNCTION validate_share_code(text) TO anon, authenticated;

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -1,13 +1,6 @@
 import { createServerClient } from '@supabase/ssr'
 import { NextResponse, type NextRequest } from 'next/server'
-
-// Allowed origins for CORS (SECURITY FIX - CWE-942)
-const ALLOWED_ORIGINS = [
-  'https://deepterm.app',
-  'https://www.deepterm.app',
-  'https://deepterm.vercel.app',
-  // Development origins are handled separately below
-]
+import { isTrustedOrigin } from '@/lib/auth/trustedOrigins'
 
 // Only allow 'unsafe-eval' in development (needed for Next.js HMR/React DevTools)
 const IS_DEV = process.env.NODE_ENV === 'development'
@@ -21,9 +14,11 @@ function buildCspHeader(nonce: string): string {
     "font-src 'self' data: https://fonts.gstatic.com",
     "connect-src 'self' https://generativelanguage.googleapis.com https://challenges.cloudflare.com https://www.googletagmanager.com https://www.google-analytics.com https://region1.google-analytics.com https://us.i.posthog.com https://*.posthog.com https://*.supabase.co",
     "frame-src 'self' https://challenges.cloudflare.com",
-    "frame-ancestors 'self'",
+    "frame-ancestors 'none'",
+    "object-src 'none'",
     "base-uri 'self'",
-    "form-action 'self'"
+    "form-action 'self'",
+    ...(IS_DEV ? [] : ["upgrade-insecure-requests"]),
   ].join('; ')
 }
 
@@ -70,18 +65,21 @@ export async function proxy(request: NextRequest) {
   // Set CSP with nonce (replaces static unsafe-inline from next.config.ts)
   response.headers.set('Content-Security-Policy', buildCspHeader(nonce))
 
-  // CORS: Only allow trusted origins (SECURITY FIX)
-  if (origin) {
-    const isDev = process.env.NODE_ENV === 'development'
-    const isAllowed = ALLOWED_ORIGINS.includes(origin) ||
-      (isDev && origin.startsWith('http://localhost'))
+  // CORS only on API routes. Reflecting Origin on every document response
+  // is unnecessary and widens the credentialed CORS surface.
+  if (pathname.startsWith('/api/') && origin && isTrustedOrigin(origin)) {
+    response.headers.set('Access-Control-Allow-Origin', origin)
+    response.headers.set('Vary', 'Origin')
+    response.headers.set('Access-Control-Allow-Credentials', 'true')
+    response.headers.set('Access-Control-Allow-Methods', 'GET, POST, PUT, PATCH, DELETE, OPTIONS')
+    response.headers.set('Access-Control-Allow-Headers', 'Content-Type, Authorization')
+  }
 
-    if (isAllowed) {
-      response.headers.set('Access-Control-Allow-Origin', origin)
-      response.headers.set('Access-Control-Allow-Credentials', 'true')
-      response.headers.set('Access-Control-Allow-Methods', 'GET, POST, PUT, DELETE, OPTIONS')
-      response.headers.set('Access-Control-Allow-Headers', 'Content-Type, Authorization')
-    }
+  if (
+    pathname.startsWith('/api/generate-') ||
+    pathname.startsWith('/api/share')
+  ) {
+    response.headers.set('Cache-Control', 'private, no-store')
   }
 
   // Handle preflight requests
@@ -110,7 +108,18 @@ export async function proxy(request: NextRequest) {
           })
           // Re-apply CSP with nonce on the new response
           newResponse.headers.set('Content-Security-Policy', buildCspHeader(nonce))
-          // Set cookies on response
+          const allowOrigin = response.headers.get('Access-Control-Allow-Origin')
+          if (allowOrigin) {
+            newResponse.headers.set('Access-Control-Allow-Origin', allowOrigin)
+            newResponse.headers.set('Vary', 'Origin')
+            newResponse.headers.set('Access-Control-Allow-Credentials', 'true')
+            newResponse.headers.set('Access-Control-Allow-Methods', 'GET, POST, PUT, PATCH, DELETE, OPTIONS')
+            newResponse.headers.set('Access-Control-Allow-Headers', 'Content-Type, Authorization')
+          }
+          const cacheControl = response.headers.get('Cache-Control')
+          if (cacheControl) {
+            newResponse.headers.set('Cache-Control', cacheControl)
+          }
           cookiesToSet.forEach(({ name, value, options }) =>
             newResponse.cookies.set(name, value, options)
           )

--- a/src/tests/api/generate-cards.integration.test.ts
+++ b/src/tests/api/generate-cards.integration.test.ts
@@ -84,7 +84,7 @@ describe('POST /api/generate-cards', () => {
         )
       }
       return originalFetch(url)
-    }) as typeof fetch
+    }) as unknown as typeof fetch
     resetAllMocks()
     mockCheckAndIncrementAIUsage.mockClear()
     mockGenerateContentWithRotation.mockClear()

--- a/src/tests/services/turnstile.test.ts
+++ b/src/tests/services/turnstile.test.ts
@@ -45,7 +45,7 @@ describe("verifyTurnstileToken", () => {
       Promise.resolve(
         new Response(JSON.stringify({ success: true, hostname: "localhost" }), { status: 200 }),
       ),
-    ) as typeof fetch;
+    ) as unknown as typeof fetch;
 
     const result = await verifyTurnstileToken("valid-token", requestWithIp(), enabledConfig);
     expect(result).toEqual({ ok: true });
@@ -58,7 +58,7 @@ describe("verifyTurnstileToken", () => {
           status: 200,
         }),
       ),
-    ) as typeof fetch;
+    ) as unknown as typeof fetch;
 
     const result = await verifyTurnstileToken("bad-token", requestWithIp(), enabledConfig);
     expect(result.ok).toBe(false);
@@ -69,7 +69,7 @@ describe("verifyTurnstileToken", () => {
       Promise.resolve(
         new Response(JSON.stringify({ success: true, hostname: "evil.example" }), { status: 200 }),
       ),
-    ) as typeof fetch;
+    ) as unknown as typeof fetch;
 
     const result = await verifyTurnstileToken("valid-token", requestWithIp(), enabledConfig);
     expect(result.ok).toBe(false);

--- a/src/tests/trustedOrigins.test.ts
+++ b/src/tests/trustedOrigins.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from 'bun:test'
+import { NextRequest } from 'next/server'
+import {
+  CANONICAL_ORIGIN,
+  getTrustedOrigin,
+  isTrustedOrigin,
+} from '@/lib/auth/trustedOrigins'
+import { forbiddenUnlessSameOrigin } from '@/lib/auth/assertSameOrigin'
+
+describe('trustedOrigins', () => {
+  it('allows the canonical production origin', () => {
+    expect(isTrustedOrigin('https://deepterm.tech')).toBe(true)
+    expect(isTrustedOrigin('https://www.deepterm.tech')).toBe(true)
+  })
+
+  it('allows legacy and preview origins', () => {
+    expect(isTrustedOrigin('https://deepterm.app')).toBe(true)
+    expect(isTrustedOrigin('https://deepterm.vercel.app')).toBe(true)
+  })
+
+  it('rejects unknown and protocol-relative origins', () => {
+    expect(isTrustedOrigin('https://evil.example')).toBe(false)
+    expect(isTrustedOrigin('https://deepterm.tech.evil.com')).toBe(false)
+    expect(isTrustedOrigin(null)).toBe(false)
+  })
+
+  it('never reflects an untrusted request host for redirects', () => {
+    expect(getTrustedOrigin(new URL('https://evil.example/auth/callback'))).toBe(
+      CANONICAL_ORIGIN,
+    )
+    expect(getTrustedOrigin(new URL('https://deepterm.tech/auth/callback'))).toBe(
+      'https://deepterm.tech',
+    )
+  })
+})
+
+describe('forbiddenUnlessSameOrigin', () => {
+  it('allows a trusted Origin', () => {
+    const request = new NextRequest('https://deepterm.tech/api/share', {
+      method: 'POST',
+      headers: { origin: 'https://deepterm.tech' },
+    })
+    expect(forbiddenUnlessSameOrigin(request)).toBeNull()
+  })
+
+  it('rejects a cross-site Origin', async () => {
+    const request = new NextRequest('https://deepterm.tech/api/share', {
+      method: 'POST',
+      headers: { origin: 'https://evil.example' },
+    })
+    const response = forbiddenUnlessSameOrigin(request)
+    expect(response?.status).toBe(403)
+    expect(response?.headers.get('Cache-Control')).toBe('private, no-store')
+  })
+
+  it('falls back to a trusted Referer when Origin is absent', () => {
+    const request = new NextRequest('https://deepterm.tech/api/share', {
+      method: 'POST',
+      headers: { referer: 'https://deepterm.tech/materials' },
+    })
+    expect(forbiddenUnlessSameOrigin(request)).toBeNull()
+  })
+})


### PR DESCRIPTION
## TL;DR
Stop cross-site POSTs to cookie-auth APIs. One origin allowlist. Tighter CSP. DB EXECUTE lockdown is **already in prod** — this PR is the app + a paper trail of that SQL.

Production domain is **deepterm.app only** (www allowed). Not `.tech`, not vercel.app.

`AGENTS.md` is the agent source of truth (README env/SQL is stale). Skip unless you care.

## Review these (5 min)
1. `src/lib/auth/assertSameOrigin.ts` — Origin/Referer check on cookie-auth routes
2. `src/lib/auth/trustedOrigins.ts` — canonical host is `deepterm.app`
3. `src/proxy.ts` — CORS only on `/api/*`, `frame-ancestors 'none'`
4. `src/app/api/share/route.ts` — UUID validation + CSRF
5. `src/app/auth/callback/route.ts` — redirect origin is not taken from `Host`

Skip Footer year / dashboard chrome split. Cosmetic.

## Already applied (do not re-run)
`src/lib/supabase/003_security_hardening.sql` on `lopurzvtignkqyubqgtz`:
- anon cannot execute user RPCs (`add_xp`, usage, etc.)
- admin RPCs = `service_role` only
- blog/share public RPCs stay readable without login

## Don't trip over
Cron routes are **not** Origin-checked. They use Bearer `CRON_SECRET`.

If the Origin check is too strict, generate/share buttons 403. Revert this branch.

## Test
- [ ] Logged-in generate-cards / generate-reviewer still works from the site
- [ ] Share create / copy / delete still works
- [ ] OAuth callback still returns to deepterm.app
- [ ] Blog still public without login