### PR TITLE
Canonical origin is deepterm.app only

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,7 +2,7 @@
 
 AI study app: notes/PDFs → flashcards, reviewers, practice tests.
 
-- Canonical origin: `https://deepterm.tech` (legacy: `deepterm.app`, `deepterm.vercel.app`)
+- Canonical origin: `https://deepterm.app` (www allowed; nothing else)
 - Repo: `4regab/deepterm`
 - Live Supabase: `lopurzvtignkqyubqgtz` (`ap-southeast-1`)
 

--- a/README.md
+++ b/README.md
@@ -271,7 +271,7 @@ GEMINI_API_KEY_5=your_gemini_api_key_5
 # Cloudflare Turnstile - Bot protection (optional, auth works without it)
 NEXT_PUBLIC_TURNSTILE_SITE_KEY=your_turnstile_site_key
 TURNSTILE_SECRET=your_turnstile_secret
-TURNSTILE_HOSTNAMES=deepterm.app,www.deepterm.app,localhost,127.0.0.1,deepterm.vercel.app
+TURNSTILE_HOSTNAMES=deepterm.app,www.deepterm.app,localhost,127.0.0.1
 
 # Unsplash - Blog hero images (optional)
 UNSPLASH_ACCESS_KEY=your_unsplash_access_key

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -279,4 +279,4 @@ Disallow: /dashboard/
 # ============================================
 # Sitemap & LLM Discovery
 # ============================================
-Sitemap: https://deepterm.tech/sitemap.xml
+Sitemap: https://deepterm.app/sitemap.xml

--- a/src/app/api/blog/[slug]/text/route.ts
+++ b/src/app/api/blog/[slug]/text/route.ts
@@ -14,7 +14,7 @@ export async function GET(
         return new NextResponse('Post not found', { status: 404 })
     }
 
-    const baseUrl = 'https://deepterm.tech'
+    const baseUrl = 'https://deepterm.app'
 
     const meta: string[] = []
     if (post.category_name) meta.push('Category: ' + post.category_name)

--- a/src/app/api/og/blog/route.tsx
+++ b/src/app/api/og/blog/route.tsx
@@ -132,7 +132,7 @@ export async function GET(request: NextRequest) {
                 DeepTerm
               </span>
               <span style={{ fontSize: '14px', color: 'rgba(255, 255, 255, 0.5)' }}>
-                deepterm.tech/blog
+                deepterm.app/blog
               </span>
             </div>
           </div>

--- a/src/app/api/og/share/route.tsx
+++ b/src/app/api/og/share/route.tsx
@@ -121,7 +121,7 @@ export async function GET(request: NextRequest) {
             fontSize: '18px',
           }}
         >
-          deepterm.tech
+          deepterm.app
         </div>
       </div>
     ),

--- a/src/app/opengraph-image.tsx
+++ b/src/app/opengraph-image.tsx
@@ -110,7 +110,7 @@ export default async function Image() {
             fontSize: '20px',
           }}
         >
-          deepterm.tech
+          deepterm.app
         </div>
       </div>
     ),

--- a/src/app/twitter-image.tsx
+++ b/src/app/twitter-image.tsx
@@ -105,7 +105,7 @@ export default async function Image() {
             fontSize: '20px',
           }}
         >
-          deepterm.tech
+          deepterm.app
         </div>
       </div>
     ),

--- a/src/lib/auth/trustedOrigins.ts
+++ b/src/lib/auth/trustedOrigins.ts
@@ -1,15 +1,12 @@
 /**
  * Single allowlist for Origin/Host checks (CORS, CSRF, OAuth redirects).
- * Production canonical host is deepterm.tech; .app and vercel.app are legacy.
+ * Production domain is deepterm.app only.
  */
-export const CANONICAL_ORIGIN = 'https://deepterm.tech'
+export const CANONICAL_ORIGIN = 'https://deepterm.app'
 
 export const TRUSTED_ORIGINS = [
   CANONICAL_ORIGIN,
-  'https://www.deepterm.tech',
-  'https://deepterm.app',
   'https://www.deepterm.app',
-  'https://deepterm.vercel.app',
 ] as const
 
 export const TRUSTED_PRODUCTION_ORIGINS = TRUSTED_ORIGINS

--- a/src/lib/blog/prompts.ts
+++ b/src/lib/blog/prompts.ts
@@ -1,6 +1,6 @@
 // Blog article generation prompts for Gemini AI
 
-export const BLOG_ARTICLE_SYSTEM_PROMPT = `You are an expert educational content writer for DeepTerm (deepterm.tech), an AI-powered study platform. Write in a professional yet accessible educational tone that speaks directly to college students and researchers.
+export const BLOG_ARTICLE_SYSTEM_PROMPT = `You are an expert educational content writer for DeepTerm (deepterm.app), an AI-powered study platform. Write in a professional yet accessible educational tone that speaks directly to college students and researchers.
 
 ## Tone & Voice
 - Use second person ("you," "your") to create engagement while maintaining authority

--- a/src/lib/seo.ts
+++ b/src/lib/seo.ts
@@ -7,8 +7,8 @@ export function serializeJsonLd(data: unknown): string {
 export const siteConfig = {
   name: 'DeepTerm',
   description: 'AI-powered study companion that transforms any material into flashcards, reviewers, and practice tests. Free alternative to Quizlet and Gizmo.',
-  url: 'https://deepterm.tech',
-  ogImage: 'https://deepterm.tech/opengraph-image',
+  url: 'https://deepterm.app',
+  ogImage: 'https://deepterm.app/opengraph-image',
   creator: 'DeepTerm',
   keywords: [
     'study app',
@@ -24,7 +24,7 @@ export const siteConfig = {
     'active learning',
     'study techniques',
   ],
-  authors: [{ name: 'DeepTerm', url: 'https://deepterm.tech' }],
+  authors: [{ name: 'DeepTerm', url: 'https://deepterm.app' }],
   links: {
     github: 'https://github.com/4regab/deepterm',
     twitter: 'https://twitter.com/deepterm',

--- a/src/tests/auth/redirect.test.ts
+++ b/src/tests/auth/redirect.test.ts
@@ -4,21 +4,23 @@ import { resolveAuthCallbackPath, sanitizeRedirectPath } from '@/lib/auth/redire
 
 describe('trustedOrigins', () => {
   it('includes the canonical production domain from siteConfig', () => {
-    expect(PRIMARY_ORIGIN).toBe('https://deepterm.tech')
-    expect(TRUSTED_PRODUCTION_ORIGINS).toContain('https://deepterm.tech')
-    expect(TRUSTED_PRODUCTION_ORIGINS).toContain('https://www.deepterm.tech')
+    expect(PRIMARY_ORIGIN).toBe('https://deepterm.app')
+    expect(TRUSTED_PRODUCTION_ORIGINS).toContain('https://deepterm.app')
+    expect(TRUSTED_PRODUCTION_ORIGINS).toContain('https://www.deepterm.app')
+    expect(TRUSTED_PRODUCTION_ORIGINS).not.toContain('https://deepterm.tech')
+    expect(TRUSTED_PRODUCTION_ORIGINS).not.toContain('https://deepterm.vercel.app')
   })
 
   it('accepts known production origins and localhost in development', () => {
-    expect(isTrustedOrigin('https://deepterm.tech')).toBe(true)
     expect(isTrustedOrigin('https://deepterm.app')).toBe(true)
+    expect(isTrustedOrigin('https://deepterm.tech')).toBe(false)
     expect(isTrustedOrigin('https://evil.example')).toBe(false)
     expect(isTrustedOrigin('http://localhost:3000', true)).toBe(true)
     expect(isTrustedOrigin('http://localhost:3000', false)).toBe(false)
   })
 
   it('falls back to the canonical origin instead of an untrusted Host header', () => {
-    expect(getTrustedOrigin('https://evil.example')).toBe('https://deepterm.tech')
+    expect(getTrustedOrigin('https://evil.example')).toBe('https://deepterm.app')
     expect(getTrustedOrigin('https://deepterm.app')).toBe('https://deepterm.app')
   })
 })

--- a/src/tests/trustedOrigins.test.ts
+++ b/src/tests/trustedOrigins.test.ts
@@ -8,19 +8,17 @@ import {
 import { forbiddenUnlessSameOrigin } from '@/lib/auth/assertSameOrigin'
 
 describe('trustedOrigins', () => {
-  it('allows the canonical production origin', () => {
-    expect(isTrustedOrigin('https://deepterm.tech')).toBe(true)
-    expect(isTrustedOrigin('https://www.deepterm.tech')).toBe(true)
-  })
-
-  it('allows legacy and preview origins', () => {
+  it('allows the production domain only', () => {
     expect(isTrustedOrigin('https://deepterm.app')).toBe(true)
-    expect(isTrustedOrigin('https://deepterm.vercel.app')).toBe(true)
+    expect(isTrustedOrigin('https://www.deepterm.app')).toBe(true)
   })
 
-  it('rejects unknown and protocol-relative origins', () => {
+  it('rejects every other host, including old preview URLs', () => {
+    expect(isTrustedOrigin('https://deepterm.tech')).toBe(false)
+    expect(isTrustedOrigin('https://www.deepterm.tech')).toBe(false)
+    expect(isTrustedOrigin('https://deepterm.vercel.app')).toBe(false)
     expect(isTrustedOrigin('https://evil.example')).toBe(false)
-    expect(isTrustedOrigin('https://deepterm.tech.evil.com')).toBe(false)
+    expect(isTrustedOrigin('https://deepterm.app.evil.com')).toBe(false)
     expect(isTrustedOrigin(null)).toBe(false)
   })
 
@@ -28,23 +26,23 @@ describe('trustedOrigins', () => {
     expect(getTrustedOrigin(new URL('https://evil.example/auth/callback'))).toBe(
       CANONICAL_ORIGIN,
     )
-    expect(getTrustedOrigin(new URL('https://deepterm.tech/auth/callback'))).toBe(
-      'https://deepterm.tech',
+    expect(getTrustedOrigin(new URL('https://deepterm.app/auth/callback'))).toBe(
+      'https://deepterm.app',
     )
   })
 })
 
 describe('forbiddenUnlessSameOrigin', () => {
   it('allows a trusted Origin', () => {
-    const request = new NextRequest('https://deepterm.tech/api/share', {
+    const request = new NextRequest('https://deepterm.app/api/share', {
       method: 'POST',
-      headers: { origin: 'https://deepterm.tech' },
+      headers: { origin: 'https://deepterm.app' },
     })
     expect(forbiddenUnlessSameOrigin(request)).toBeNull()
   })
 
   it('rejects a cross-site Origin', async () => {
-    const request = new NextRequest('https://deepterm.tech/api/share', {
+    const request = new NextRequest('https://deepterm.app/api/share', {
       method: 'POST',
       headers: { origin: 'https://evil.example' },
     })
@@ -54,9 +52,9 @@ describe('forbiddenUnlessSameOrigin', () => {
   })
 
   it('falls back to a trusted Referer when Origin is absent', () => {
-    const request = new NextRequest('https://deepterm.tech/api/share', {
+    const request = new NextRequest('https://deepterm.app/api/share', {
       method: 'POST',
-      headers: { referer: 'https://deepterm.tech/materials' },
+      headers: { referer: 'https://deepterm.app/materials' },
     })
     expect(forbiddenUnlessSameOrigin(request)).toBeNull()
   })


### PR DESCRIPTION
## TL;DR
Production domain is **deepterm.app**. `#38` merged with `deepterm.tech` still listed as canonical. This drops `.tech` and `vercel.app` from the allowlist, SEO, OG, robots, and tests.

`www.deepterm.app` stays allowed. Nothing else.

## Review
`src/lib/auth/trustedOrigins.ts` — `CANONICAL_ORIGIN = https://deepterm.app`

## Test
- [x] Site URLs and OG tags point at deepterm.app
- [x] OAuth callback still lands on deepterm.app
- [x] Cross-origin POSTs from `.tech` / vercel.app get 403