### PR TITLE
fix(study): restore SRS, reviewer modes, folders, and Gemini rotation

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -41,6 +41,9 @@ const securityHeaders = [
 
 const nextConfig: NextConfig = {
   reactCompiler: true,
+  // Keep the repo AGENTS.md as the source of truth. Next 16's `next dev`
+  // otherwise appends a generated agent-rules block on every boot.
+  agentRules: false,
   // Optimize barrel file imports - transforms lucide-react imports to direct imports at build time
   // This reduces bundle size by ~1MB and improves cold start by 200-800ms
   experimental: {

--- a/src/app/(dashboard)/dashboard/page.tsx
+++ b/src/app/(dashboard)/dashboard/page.tsx
@@ -79,6 +79,19 @@ const getDashboardData = cache(async () => {
       .limit(100),
   ]);
 
+  if (dashboardResult.error) {
+    console.error("[dashboard] get_dashboard_data failed:", dashboardResult.error.message);
+  }
+  if (flashcardSetsResult.error) {
+    console.error("[dashboard] flashcard sets failed:", flashcardSetsResult.error.message);
+  }
+  if (reviewersResult.error) {
+    console.error("[dashboard] reviewers failed:", reviewersResult.error.message);
+  }
+  if (dueCardsResult.error) {
+    console.error("[dashboard] due cards failed:", dueCardsResult.error.message);
+  }
+
   const dashboardData = (dashboardResult.data as DashboardData | null) ?? null;
 
   const rawFlashcardSets = (flashcardSetsResult.data ?? []) as unknown as FlashcardSetWithCardsRow[];

--- a/src/app/(dashboard)/materials/[id]/flashcards/page.tsx
+++ b/src/app/(dashboard)/materials/[id]/flashcards/page.tsx
@@ -12,6 +12,7 @@ import { getStudySettings, StudySettings } from "@/utils/studySettings";
 import { createClient } from "@/config/supabase/client";
 import { logFlashcardReview, batchUpdateFlashcardStatuses, addXP, XP_REWARDS, type FlashcardStatusUpdate } from "@/services/activity";
 import { useXPStore } from "@/lib/stores";
+import { loadStudyDeck } from "@/lib/materials/studyCards";
 
 interface Flashcard {
     id: string;
@@ -50,18 +51,14 @@ export default function FlashcardsPage() {
         useXPStore.getState().fetchXPStats();
 
         const supabase = createClient();
-        const { data } = await supabase
-            .from("flashcards")
-            .select("id, front, back, status")
-            .eq("set_id", params.id)
-            .order("created_at");
+        const deck = await loadStudyDeck(supabase, String(params.id));
 
-        if (data && data.length > 0) {
-            const cards: Flashcard[] = data.map(c => ({
-                id: c.id,
-                term: c.front,
-                definition: c.back,
-                status: (c.status || 'new') as Flashcard['status'],
+        if (deck && deck.cards.length > 0) {
+            const cards: Flashcard[] = deck.cards.map((card) => ({
+                id: card.id,
+                term: card.term,
+                definition: card.definition,
+                status: card.status,
             }));
             setAllCards(cards);
             setStudySession(createInitialSession(cards, getStudySettings()));
@@ -88,8 +85,15 @@ export default function FlashcardsPage() {
 
     if (!studySession || studySession.cards.length === 0) {
         return (
-            <div className="min-h-screen bg-background flex items-center justify-center">
-                <p className="text-muted-foreground">No flashcards found</p>
+            <div className="min-h-screen bg-background flex flex-col items-center justify-center gap-3">
+                <p className="text-muted-foreground">No study cards found</p>
+                <button
+                    type="button"
+                    onClick={() => router.back()}
+                    className="text-sm text-brand hover:underline"
+                >
+                    Go back
+                </button>
             </div>
         );
     }

--- a/src/app/(dashboard)/materials/[id]/learn/page.tsx
+++ b/src/app/(dashboard)/materials/[id]/learn/page.tsx
@@ -15,6 +15,7 @@ import { createClient } from "@/config/supabase/client";
 import { useXPStore } from "@/lib/stores";
 import { addXP, recordStudyActivity, batchUpdateFlashcardStatuses, applyCardReview, XP_REWARDS, type FlashcardStatusUpdate } from "@/services/activity";
 import { expectedWrittenAnswer, promptLabelForFrontSide } from "@/utils/reviewerTerms";
+import { loadStudyDeck, type StudyCardSource } from "@/lib/materials/studyCards";
 
 type LearnStage = 'new' | 'learning' | 'almost_done' | 'mastered';
 
@@ -83,35 +84,23 @@ export default function LearnPage() {
     const [settings, setSettings] = useState<StudySettings>(() => getStudySettings());
     const [cards, setCards] = useState<LearnCard[]>([]);
     const [sessionQueue, setSessionQueue] = useState<SessionCard[]>([]);
+    const [deckSource, setDeckSource] = useState<StudyCardSource>("flashcard");
 
     const fetchCards = useCallback(async () => {
         // Fetch XP stats for display
         useXPStore.getState().fetchXPStats();
 
         const supabase = createClient();
-        const [{ data }, { data: setRow }] = await Promise.all([
-            supabase
-                .from("flashcards")
-                .select("id, front, back, status")
-                .eq("set_id", params.id)
-                .order("created_at"),
-            supabase
-                .from("flashcard_sets")
-                .select("title")
-                .eq("id", params.id)
-                .maybeSingle(),
-        ]);
+        const deck = await loadStudyDeck(supabase, String(params.id));
 
-        if (setRow?.title) {
-            setMaterialTitle(setRow.title);
-        }
-
-        if (data && data.length > 0) {
-            const loadedCards: LearnCard[] = data.map(c => ({
-                id: c.id,
-                term: c.front,
-                definition: c.back,
-                stage: (c.status === 'review' ? 'almost_done' : c.status || 'new') as LearnStage,
+        if (deck) {
+            setMaterialTitle(deck.title);
+            setDeckSource(deck.source);
+            const loadedCards: LearnCard[] = deck.cards.map((card) => ({
+                id: card.id,
+                term: card.term,
+                definition: card.definition,
+                stage: (card.status === "review" ? "almost_done" : card.status || "new") as LearnStage,
             }));
             setCards(loadedCards);
             setSessionQueue(buildSessionQueue(loadedCards, getStudySettings()));
@@ -162,10 +151,17 @@ export default function LearnPage() {
         const currentCard = sessionQueue[currentIndex];
 
         const supabase = createClient();
-        await supabase
-            .from("flashcards")
-            .update({ front: editTerm.trim(), back: editDefinition.trim() })
-            .eq("id", currentCard.id);
+        if (deckSource === "reviewer") {
+            await supabase
+                .from("reviewer_terms")
+                .update({ term: editTerm.trim(), definition: editDefinition.trim() })
+                .eq("id", currentCard.id);
+        } else {
+            await supabase
+                .from("flashcards")
+                .update({ front: editTerm.trim(), back: editDefinition.trim() })
+                .eq("id", currentCard.id);
+        }
 
         // Update local state - cards, sessionQueue
         setCards(prev => prev.map(c =>
@@ -236,10 +232,12 @@ export default function LearnPage() {
         // Track status update locally (no network request yet - batched at session end)
         const dbStatus = nextStage === 'almost_done' ? 'review' : nextStage;
         const newPendingUpdate: FlashcardStatusUpdate = { id: currentCard.id, status: dbStatus as 'new' | 'learning' | 'review' | 'mastered' };
-        setPendingUpdates(prev => [...prev, newPendingUpdate]);
-        void applyCardReview(currentCard.id, correct).catch((error) => {
-            console.error("Failed to persist SM-2 review:", error);
-        });
+        if (deckSource === "flashcard") {
+            setPendingUpdates(prev => [...prev, newPendingUpdate]);
+            void applyCardReview(currentCard.id, correct).catch((error) => {
+                console.error("Failed to persist SM-2 review:", error);
+            });
+        }
 
         const isMasteredCard = currentCard.stage === 'mastered';
         setCards(prev => prev.map(c => c.id === currentCard.id
@@ -267,7 +265,7 @@ export default function LearnPage() {
         } else {
             // Session complete - batch update all flashcard statuses and persist XP/activity
             const allUpdates = [...pendingUpdates, newPendingUpdate];
-            if (allUpdates.length > 0) {
+            if (deckSource === "flashcard" && allUpdates.length > 0) {
                 await batchUpdateFlashcardStatuses(allUpdates);
             }
 
@@ -280,7 +278,7 @@ export default function LearnPage() {
             await recordStudyActivity({ flashcards: sessionQueue.length, minutes: minutesStudied });
             setSessionComplete(true);
         }
-    }, [currentIndex, pendingResult, sessionQueue, sessionStats.xpGained, sessionStats.startTime, pendingUpdates]);
+    }, [currentIndex, pendingResult, sessionQueue, sessionStats.xpGained, sessionStats.startTime, pendingUpdates, deckSource]);
 
     // Auto-next effect - triggers handleNext after configured duration
     useSyncExternalStore(
@@ -392,8 +390,15 @@ export default function LearnPage() {
 
     if (sessionQueue.length === 0 && !sessionComplete) {
         return (
-            <div className="min-h-screen bg-background flex items-center justify-center">
-                <p className="text-muted-foreground">No flashcards found</p>
+            <div className="min-h-screen bg-background flex flex-col items-center justify-center gap-3">
+                <p className="text-muted-foreground">No study cards found</p>
+                <button
+                    type="button"
+                    onClick={() => router.back()}
+                    className="text-sm text-brand hover:underline"
+                >
+                    Go back
+                </button>
             </div>
         );
     }

--- a/src/app/(dashboard)/materials/[id]/match/page.tsx
+++ b/src/app/(dashboard)/materials/[id]/match/page.tsx
@@ -10,6 +10,7 @@ import { createClient } from "@/config/supabase/client";
 import { useXPStore } from "@/lib/stores";
 import { addXP, recordStudyActivity, applyCardReview, XP_REWARDS } from "@/services/activity";
 import { createGameCards } from "@/utils/matchGame";
+import { loadStudyDeck } from "@/lib/materials/studyCards";
 
 type CardStatus = 'new' | 'learning' | 'review' | 'mastered';
 
@@ -53,20 +54,16 @@ export default function MatchPage() {
             useXPStore.getState().fetchXPStats();
 
             const supabase = createClient();
-            const { data } = await supabase
-                .from("flashcards")
-                .select("id, front, back, status")
-                .eq("set_id", params.id)
-                .order("created_at");
+            const deck = await loadStudyDeck(supabase, String(params.id));
 
             if (!mounted) return;
 
-            if (data && data.length > 0) {
-                const fcData: FlashcardData[] = data.map(c => ({
-                    id: c.id,
-                    term: c.front,
-                    definition: c.back,
-                    status: (c.status || 'new') as CardStatus,
+            if (deck && deck.cards.length > 0) {
+                const fcData: FlashcardData[] = deck.cards.map((card) => ({
+                    id: card.id,
+                    term: card.term,
+                    definition: card.definition,
+                    status: card.status as CardStatus,
                 }));
 
                 setFlashcardData(fcData);
@@ -218,8 +215,15 @@ export default function MatchPage() {
 
     if (cards.length === 0) {
         return (
-            <div className="min-h-screen bg-background flex items-center justify-center">
-                <p className="text-muted-foreground">No flashcards found</p>
+            <div className="min-h-screen bg-background flex flex-col items-center justify-center gap-3">
+                <p className="text-muted-foreground">No study cards found</p>
+                <button
+                    type="button"
+                    onClick={() => router.back()}
+                    className="text-sm text-brand hover:underline"
+                >
+                    Go back
+                </button>
             </div>
         );
     }

--- a/src/app/(dashboard)/materials/[id]/practice/page.tsx
+++ b/src/app/(dashboard)/materials/[id]/practice/page.tsx
@@ -12,6 +12,7 @@ import { createClient } from "@/config/supabase/client";
 import { useXPStore } from "@/lib/stores";
 import { addXP, recordStudyActivity, batchUpdateFlashcardStatuses, applyCardReview, XP_REWARDS, type FlashcardStatusUpdate } from "@/services/activity";
 import { generateQuestionsFromCards, gradePracticeAnswer, type QuestionType } from "@/utils/practiceQuestions";
+import { loadStudyDeck, type StudyCardSource } from "@/lib/materials/studyCards";
 
 type CardStatus = 'new' | 'learning' | 'review' | 'mastered';
 
@@ -57,6 +58,7 @@ export default function PracticePage() {
     const router = useRouter();
     const params = useParams();
     const [flashcardData, setFlashcardData] = useState<FlashcardData[]>([]);
+    const [deckSource, setDeckSource] = useState<StudyCardSource>("flashcard");
     const [stage, setStage] = useState<Stage>("loading");
     const [questions, setQuestions] = useState<Question[]>([]);
     const [settings, setSettings] = useState<PracticeSettings>(DEFAULT_PRACTICE_SETTINGS);
@@ -68,15 +70,17 @@ export default function PracticePage() {
         useXPStore.getState().fetchXPStats();
 
         const supabase = createClient();
-        const { data } = await supabase
-            .from("flashcards")
-            .select("id, front, back, status")
-            .eq("set_id", params.id)
-            .order("created_at");
+        const deck = await loadStudyDeck(supabase, String(params.id));
 
-        if (data && data.length > 0) {
-            const cards = data.map(c => ({ id: c.id, term: c.front, definition: c.back, status: (c.status || 'new') as CardStatus }));
+        if (deck && deck.cards.length > 0) {
+            const cards = deck.cards.map((card) => ({
+                id: card.id,
+                term: card.term,
+                definition: card.definition,
+                status: card.status as CardStatus,
+            }));
             setFlashcardData(cards);
+            setDeckSource(deck.source);
             // Show config screen first
             setStage("config");
             setShowSettings(true);
@@ -134,8 +138,7 @@ export default function PracticePage() {
             setFinalXpEarned(xpEarned);
 
             const persistResults = async () => {
-                // Batch update all flashcard statuses in one request
-                if (pendingUpdates.length > 0) {
+                if (deckSource === "flashcard" && pendingUpdates.length > 0) {
                     await batchUpdateFlashcardStatuses(pendingUpdates);
                 }
 
@@ -144,23 +147,29 @@ export default function PracticePage() {
                     useXPStore.getState().fetchXPStats();
                 }
                 await recordStudyActivity({ quizzes: 1 });
-                const supabase = createClient();
-                await supabase.from("practice_sessions").insert({
-                    set_id: params.id,
-                    score: correct,
-                    total: questions.length,
-                    answers: questions.map((q) => ({
-                        id: q.id,
-                        correct: q.isCorrect,
-                        answer: q.userAnswer,
-                    })),
-                });
+                if (deckSource === "flashcard") {
+                    const supabase = createClient();
+                    const { data: { user } } = await supabase.auth.getUser();
+                    if (user) {
+                        await supabase.from("practice_sessions").insert({
+                            user_id: user.id,
+                            set_id: params.id,
+                            score: correct,
+                            total: questions.length,
+                            answers: questions.map((q) => ({
+                                id: q.id,
+                                correct: q.isCorrect,
+                                answer: q.userAnswer,
+                            })),
+                        });
+                    }
+                }
             };
             persistResults();
 
             setStage("results");
         }
-    }, [currentQuestionIndex, questions, pendingUpdates]);
+    }, [currentQuestionIndex, questions, pendingUpdates, deckSource, params.id]);
 
     const handleAnswer = useCallback(async (answer: string) => {
         const updated = [...questions];
@@ -179,9 +188,11 @@ export default function PracticePage() {
                 : 'learning';
 
             setPendingUpdates(prev => [...prev, { id: card.id, status: newStatus }]);
-            void applyCardReview(card.id, isCorrect).catch((error) => {
-                console.error("Failed to persist SM-2 review:", error);
-            });
+            if (deckSource === "flashcard") {
+                void applyCardReview(card.id, isCorrect).catch((error) => {
+                    console.error("Failed to persist SM-2 review:", error);
+                });
+            }
 
             // Update local state only
             const updatedCards = [...flashcardData];
@@ -223,7 +234,7 @@ export default function PracticePage() {
             };
             timerRef.current = setTimeout(tick, 1000);
         }
-    }, [currentQuestionIndex, questions, flashcardData, settings.answerFeedback, settings.autoNextAfterAnswer, settings.autoNextDuration, streak]);
+    }, [currentQuestionIndex, questions, flashcardData, settings.answerFeedback, settings.autoNextAfterAnswer, settings.autoNextDuration, streak, deckSource]);
 
     const startOver = () => {
         // Regenerate with current settings
@@ -338,6 +349,21 @@ export default function PracticePage() {
         return (
             <div className="min-h-screen bg-background flex items-center justify-center">
                 <Loader2 size={32} className="animate-spin text-muted-foreground" />
+            </div>
+        );
+    }
+
+    if (flashcardData.length === 0) {
+        return (
+            <div className="min-h-screen bg-background flex flex-col items-center justify-center gap-3">
+                <p className="text-muted-foreground">No study cards found</p>
+                <button
+                    type="button"
+                    onClick={() => router.back()}
+                    className="text-sm text-brand hover:underline"
+                >
+                    Go back
+                </button>
             </div>
         );
     }
@@ -651,8 +677,7 @@ export default function PracticePage() {
                                         setFinalXpEarned(xpEarned);
 
                                         const persistResults = async () => {
-                                            // Batch update all flashcard statuses in one request
-                                            if (pendingUpdates.length > 0) {
+                                            if (deckSource === "flashcard" && pendingUpdates.length > 0) {
                                                 await batchUpdateFlashcardStatuses(pendingUpdates);
                                             }
 

--- a/src/app/(dashboard)/materials/create/useCreateDraft.ts
+++ b/src/app/(dashboard)/materials/create/useCreateDraft.ts
@@ -426,6 +426,9 @@ export function useCreateDraft() {
         }
 
         const data = await response.json();
+        if (typeof data.remaining === 'number') {
+          setRemainingGenerations(data.remaining);
+        }
         const rawCards = (data.cards || []) as Array<{ term: string; definition: string }>;
         const newCards: FlashcardDraftItem[] = rawCards.map((c) => ({
           id: generateItemId(),
@@ -461,6 +464,9 @@ export function useCreateDraft() {
         }
 
         const data = await response.json();
+        if (typeof data.remaining === 'number') {
+          setRemainingGenerations(data.remaining);
+        }
         if (data.title && !title.trim()) {
           setTitle(data.title);
         }

--- a/src/lib/materials/studyCards.ts
+++ b/src/lib/materials/studyCards.ts
@@ -1,0 +1,139 @@
+export type StudyCardStatus = 'new' | 'learning' | 'review' | 'mastered'
+export type StudyCardSource = 'flashcard' | 'reviewer'
+
+export interface StudyCard {
+  id: string
+  term: string
+  definition: string
+  status: StudyCardStatus
+  source: StudyCardSource
+}
+
+export interface StudyDeck {
+  title: string
+  source: StudyCardSource
+  cards: StudyCard[]
+}
+
+export interface FlashcardStudyRow {
+  id: string
+  front: string
+  back: string
+  status?: string | null
+}
+
+export interface ReviewerTermStudyRow {
+  id: string
+  term: string
+  definition: string
+}
+
+export interface ReviewerCategoryStudyRow {
+  reviewer_terms?: ReviewerTermStudyRow[] | null
+}
+
+const FLASHCARD_STATUSES = new Set<StudyCardStatus>(['new', 'learning', 'review', 'mastered'])
+
+function toStatus(value: string | null | undefined): StudyCardStatus {
+  if (value && FLASHCARD_STATUSES.has(value as StudyCardStatus)) {
+    return value as StudyCardStatus
+  }
+  return 'new'
+}
+
+export function toStudyCardsFromFlashcards(rows: FlashcardStudyRow[]): StudyCard[] {
+  return rows.map((row) => ({
+    id: row.id,
+    term: row.front,
+    definition: row.back,
+    status: toStatus(row.status),
+    source: 'flashcard',
+  }))
+}
+
+export function toStudyCardsFromReviewerCategories(
+  categories: ReviewerCategoryStudyRow[],
+): StudyCard[] {
+  return categories.flatMap((category) =>
+    (category.reviewer_terms ?? []).map((term) => ({
+      id: term.id,
+      term: term.term,
+      definition: term.definition,
+      status: 'new' as const,
+      source: 'reviewer' as const,
+    })),
+  )
+}
+
+type QueryResult<T> = PromiseLike<{ data: T | null; error: unknown }>
+
+/**
+ * Minimal PostgREST surface used by study modes. Typed loosely so the real
+ * supabase-js builder (which is recursively huge) stays assignable.
+ */
+export interface StudyCardsClient {
+  from: (table: string) => {
+    select: (columns: string) => {
+      eq: (column: string, value: string) => {
+        order: (column: string) => QueryResult<unknown>
+        maybeSingle: () => QueryResult<unknown>
+      }
+    }
+  }
+}
+
+/**
+ * Load a study deck from a flashcard set, or fall back to reviewer terms.
+ * Reviewer Learn/Practice links use the same /materials/[id] routes.
+ */
+export async function loadStudyDeck(
+  client: unknown,
+  materialId: string,
+): Promise<StudyDeck | null> {
+  const db = client as StudyCardsClient
+  const flashcardsResult = await db
+    .from('flashcards')
+    .select('id, front, back, status')
+    .eq('set_id', materialId)
+    .order('created_at')
+
+  const flashcardRows = (flashcardsResult.data ?? []) as FlashcardStudyRow[]
+  if (flashcardRows.length > 0) {
+    const setResult = await db
+      .from('flashcard_sets')
+      .select('title')
+      .eq('id', materialId)
+      .maybeSingle()
+    const title = (setResult.data as { title?: string } | null)?.title ?? 'Flashcards'
+    return {
+      title,
+      source: 'flashcard',
+      cards: toStudyCardsFromFlashcards(flashcardRows),
+    }
+  }
+
+  const categoriesResult = await db
+    .from('reviewer_categories')
+    .select('id, reviewer_terms(id, term, definition)')
+    .eq('reviewer_id', materialId)
+    .order('created_at')
+
+  const categoryRows = (categoriesResult.data ?? []) as ReviewerCategoryStudyRow[]
+  const cards = toStudyCardsFromReviewerCategories(categoryRows)
+  if (cards.length === 0) {
+    return null
+  }
+
+  const reviewerResult = await db
+    .from('reviewers')
+    .select('title')
+    .eq('id', materialId)
+    .maybeSingle()
+  const title = (reviewerResult.data as { title?: string } | null)?.title ?? 'Reviewer'
+
+  return {
+    title,
+    source: 'reviewer',
+    cards,
+  }
+}

--- a/src/lib/supabase/004_study_integrity.sql
+++ b/src/lib/supabase/004_study_integrity.sql
@@ -2,6 +2,10 @@
 -- Notes for live DB (do not replay 001–003). Helpers live in private;
 -- search_path = ''; GRANT EXECUTE only to authenticated (never PUBLIC).
 -- Apply in the Supabase SQL editor after review.
+--
+-- STATUS: Do not replay this file as a whole. SRS columns, practice_sessions,
+-- and refund_ai_usage were applied separately as 006. increment_stat / add_xp /
+-- record_study_activity already exist live with auth.uid() checks.
 
 create schema if not exists private;
 

--- a/src/lib/supabase/005_folders.sql
+++ b/src/lib/supabase/005_folders.sql
@@ -8,6 +8,11 @@
 -- and verified against pg_constraint / pg_indexes / pg_policies. Do not re-run
 -- it blindly.
 --
+-- Follow-up: 007_folders_normalize_security_definer.sql makes
+-- private.folders_normalize() SECURITY DEFINER. The original invoker trigger
+-- cannot call private.sanitize_folder_name() because authenticated has no
+-- USAGE on schema private.
+--
 -- Supersedes the `add column if not exists folder text` lines that 004 once
 -- carried. That flat text column was never applied and must not be added: the
 -- deployed model is relational (public.folders + folder_id FKs).
@@ -85,6 +90,8 @@ grant select, insert, update, delete on table public.folders to authenticated;
 
 -- Normalizes the name and pins user_id to auth.uid() server-side, so the
 -- client never gets to choose an owner. Runs BEFORE the RLS WITH CHECK.
+-- Live copy is SECURITY DEFINER (see 007). Kept invoker here so this file
+-- matches the original 20260825024810 migration text.
 create or replace function private.folders_normalize()
 returns trigger
 language plpgsql

--- a/src/lib/supabase/006_srs_columns_and_ai_refund.sql
+++ b/src/lib/supabase/006_srs_columns_and_ai_refund.sql
@@ -1,0 +1,93 @@
+-- 006_srs_columns_and_ai_refund.sql
+-- Notes for live DB (do not replay 001-003). Helpers live in private;
+-- search_path = ''; GRANT EXECUTE only to authenticated (never PUBLIC).
+--
+-- STATUS: APPLIED to lopurzvtignkqyubqgtz as migration
+-- srs_columns_ai_refund_practice_sessions. This is the in-repo record of the
+-- additive pieces from 004 that were still missing: flashcard SRS columns,
+-- practice_sessions, and refund_ai_usage. Do not re-run it blindly.
+--
+-- Intentionally omitted from 004: increment_stat / add_xp / record_study_activity
+-- replacements, copy_shared_material, consume_share_rate_limit, expires_at.
+-- Those either already exist live or have app-level fallbacks.
+
+create schema if not exists private;
+
+alter table public.flashcards
+  add column if not exists ease_factor numeric not null default 2.5,
+  add column if not exists interval_days integer not null default 0,
+  add column if not exists repetitions integer not null default 0,
+  add column if not exists due_at timestamptz not null default now();
+
+create index if not exists flashcards_user_due_at_idx
+  on public.flashcards (user_id, due_at);
+
+create table if not exists public.practice_sessions (
+  id uuid primary key default gen_random_uuid(),
+  user_id uuid not null default auth.uid() references auth.users(id) on delete cascade,
+  set_id uuid references public.flashcard_sets(id) on delete cascade,
+  score integer not null default 0,
+  total integer not null default 0,
+  answers jsonb,
+  created_at timestamptz not null default now()
+);
+
+alter table public.practice_sessions enable row level security;
+
+drop policy if exists "Users can view own practice sessions" on public.practice_sessions;
+create policy "Users can view own practice sessions"
+  on public.practice_sessions for select to authenticated
+  using ((select auth.uid()) = user_id);
+
+drop policy if exists "Users can insert own practice sessions" on public.practice_sessions;
+create policy "Users can insert own practice sessions"
+  on public.practice_sessions for insert to authenticated
+  with check ((select auth.uid()) = user_id);
+
+create index if not exists practice_sessions_user_id_idx
+  on public.practice_sessions (user_id, created_at desc);
+
+create or replace function private.refund_ai_usage()
+returns boolean
+language plpgsql
+security definer
+set search_path = ''
+as $$
+declare
+  v_user_id uuid := auth.uid();
+  v_today date := (now() at time zone 'utc')::date;
+  v_count integer;
+begin
+  if v_user_id is null then
+    return false;
+  end if;
+
+  update public.ai_usage
+  set generation_count = greatest(generation_count - 1, 0),
+      updated_at = now()
+  where user_id = v_user_id
+    and reset_date = v_today
+  returning generation_count into v_count;
+
+  return found;
+end;
+$$;
+
+create or replace function public.refund_ai_usage()
+returns boolean
+language plpgsql
+security definer
+set search_path = ''
+as $$
+begin
+  return private.refund_ai_usage();
+end;
+$$;
+
+revoke all on function public.refund_ai_usage() from public;
+revoke all on function public.refund_ai_usage() from anon;
+grant execute on function public.refund_ai_usage() to authenticated;
+
+revoke all on function private.refund_ai_usage() from public;
+revoke all on function private.refund_ai_usage() from anon;
+revoke all on function private.refund_ai_usage() from authenticated;

--- a/src/lib/supabase/007_folders_normalize_security_definer.sql
+++ b/src/lib/supabase/007_folders_normalize_security_definer.sql
@@ -1,0 +1,50 @@
+-- 007_folders_normalize_security_definer.sql
+-- Notes for live DB (do not replay 001-003). Helpers live in private;
+-- search_path = ''; GRANT EXECUTE only to authenticated (never PUBLIC).
+--
+-- STATUS: APPLIED to lopurzvtignkqyubqgtz as migration
+-- folders_normalize_security_definer. Do not re-run it blindly.
+--
+-- Bug: private.folders_normalize() was SECURITY INVOKER and called
+-- private.sanitize_folder_name(). authenticated has no USAGE on schema
+-- private (002), so INSERT/UPDATE on public.folders failed with
+-- "permission denied for schema private". Folder create/rename in the
+-- library and create wizard were broken.
+--
+-- auth.uid() still reads the session JWT under SECURITY DEFINER, so the
+-- user_id pin stays honest. sanitize_folder_name stays revoked from
+-- authenticated; only the definer (postgres) executes it.
+
+create or replace function private.folders_normalize()
+returns trigger
+language plpgsql
+security definer
+set search_path = ''
+as $$
+declare
+  v_uid uuid := auth.uid();
+  v_name text;
+begin
+  if v_uid is null then
+    raise exception 'Not authenticated';
+  end if;
+  v_name := private.sanitize_folder_name(new.name);
+  if v_name is null then
+    raise exception 'Folder name is required';
+  end if;
+  new.name := v_name;
+  if tg_op = 'INSERT' then
+    new.user_id := v_uid;
+  else
+    if old.user_id is distinct from v_uid then
+      raise exception 'Not authorized';
+    end if;
+    new.user_id := old.user_id;
+  end if;
+  return new;
+end;
+$$;
+
+revoke all on function private.folders_normalize() from public;
+revoke all on function private.folders_normalize() from anon;
+grant execute on function private.folders_normalize() to authenticated;

--- a/src/services/geminiClient.ts
+++ b/src/services/geminiClient.ts
@@ -32,18 +32,32 @@ if (API_KEYS.length === 0) {
 
 console.log(`[GeminiClient] Loaded ${API_KEYS.length} API key(s)`);
 
+function errorMessage(error: unknown): string {
+  if (error instanceof Error) return error.message;
+  return String(error);
+}
+
 function isRateLimitError(error: unknown): boolean {
-  if (error instanceof Error) {
-    const message = error.message.toLowerCase();
-    return (
-      message.includes("429") ||
-      message.includes("quota") ||
-      message.includes("rate limit") ||
-      message.includes("resource exhausted") ||
-      message.includes("too many requests")
-    );
-  }
-  return false;
+  const message = errorMessage(error).toLowerCase();
+  return (
+    message.includes("429") ||
+    message.includes("quota") ||
+    message.includes("rate limit") ||
+    message.includes("resource exhausted") ||
+    message.includes("resource_exhausted") ||
+    message.includes("too many requests")
+  );
+}
+
+/** Continue the key ring for quota and dead keys; fail fast on prompt/model errors. */
+export function isRotatableKeyError(error: unknown): boolean {
+  if (isRateLimitError(error)) return true;
+  const message = errorMessage(error).toLowerCase();
+  return (
+    message.includes("api key not valid") ||
+    message.includes("api_key_invalid") ||
+    message.includes("invalid api key")
+  );
 }
 
 export interface GeminiRequestOptions {
@@ -94,11 +108,9 @@ export async function generateContentWithRotation(
       lastError = error instanceof Error ? error : new Error(String(error));
       console.log(`[GeminiClient] Key ${i + 1} failed: ${lastError.message}`);
 
-      if (!isRateLimitError(error)) {
-        // Non-rate-limit error, throw immediately
+      if (!isRotatableKeyError(error)) {
         throw lastError;
       }
-      // Rate limit error, continue to next key
     }
   }
 
@@ -119,7 +131,7 @@ export async function generateContentWithRotation(
       lastError = error instanceof Error ? error : new Error(String(error));
       console.log(`[GeminiClient] Retry key ${i + 1} failed: ${lastError.message}`);
 
-      if (!isRateLimitError(error)) {
+      if (!isRotatableKeyError(error)) {
         throw lastError;
       }
     }
@@ -163,7 +175,7 @@ export async function uploadFileWithRotation(
       lastError = error instanceof Error ? error : new Error(String(error));
       console.log(`[GeminiClient] File upload key ${i + 1} failed: ${lastError.message}`);
 
-      if (!isRateLimitError(error)) {
+      if (!isRotatableKeyError(error)) {
         throw lastError;
       }
     }

--- a/src/tests/helpers/fakeSupabase.ts
+++ b/src/tests/helpers/fakeSupabase.ts
@@ -21,6 +21,20 @@ export const LIVE_COLUMNS: Record<string, string[]> = {
     'updated_at',
     'folder_id',
   ],
+  flashcards: [
+    'id',
+    'set_id',
+    'user_id',
+    'front',
+    'back',
+    'status',
+    'last_reviewed',
+    'created_at',
+    'ease_factor',
+    'interval_days',
+    'repetitions',
+    'due_at',
+  ],
   reviewers: [
     'id',
     'user_id',
@@ -31,13 +45,27 @@ export const LIVE_COLUMNS: Record<string, string[]> = {
     'updated_at',
     'folder_id',
   ],
+  reviewer_categories: ['id', 'reviewer_id', 'user_id', 'name', 'color', 'created_at'],
+  reviewer_terms: [
+    'id',
+    'category_id',
+    'user_id',
+    'term',
+    'definition',
+    'examples',
+    'keywords',
+    'created_at',
+  ],
 }
 
 /** Embeddable relations, i.e. tables reachable by a foreign key. */
 const LIVE_RELATIONS: Record<string, string[]> = {
   folders: [],
   flashcard_sets: ['folders', 'flashcards'],
+  flashcards: [],
   reviewers: ['folders', 'reviewer_categories'],
+  reviewer_categories: ['reviewer_terms'],
+  reviewer_terms: [],
 }
 
 export interface FakeError {
@@ -233,6 +261,10 @@ class FakeBuilder implements PromiseLike<Result> {
   single() {
     this.wantSingle = true
     return this
+  }
+
+  maybeSingle() {
+    return this.single()
   }
 
   then<TResult1 = Result, TResult2 = never>(

--- a/src/tests/lib/materials/studyCards.test.ts
+++ b/src/tests/lib/materials/studyCards.test.ts
@@ -1,0 +1,137 @@
+import { describe, expect, it } from 'bun:test'
+import {
+  loadStudyDeck,
+  toStudyCardsFromFlashcards,
+  toStudyCardsFromReviewerCategories,
+} from '@/lib/materials/studyCards'
+
+describe('study card mappers', () => {
+  it('maps flashcard rows onto study cards', () => {
+    const cards = toStudyCardsFromFlashcards([
+      { id: 'c1', front: 'Mitosis', back: 'Cell division', status: 'learning' },
+      { id: 'c2', front: 'Meiosis', back: 'Gametes', status: null },
+    ])
+
+    expect(cards).toEqual([
+      { id: 'c1', term: 'Mitosis', definition: 'Cell division', status: 'learning', source: 'flashcard' },
+      { id: 'c2', term: 'Meiosis', definition: 'Gametes', status: 'new', source: 'flashcard' },
+    ])
+  })
+
+  it('flattens reviewer categories into new study cards', () => {
+    const cards = toStudyCardsFromReviewerCategories([
+      {
+        reviewer_terms: [
+          { id: 't1', term: 'Nucleus', definition: 'Control center' },
+          { id: 't2', term: 'Mitochondria', definition: 'ATP' },
+        ],
+      },
+      { reviewer_terms: [] },
+    ])
+
+    expect(cards).toEqual([
+      { id: 't1', term: 'Nucleus', definition: 'Control center', status: 'new', source: 'reviewer' },
+      { id: 't2', term: 'Mitochondria', definition: 'ATP', status: 'new', source: 'reviewer' },
+    ])
+  })
+})
+
+describe('loadStudyDeck', () => {
+  it('prefers flashcards when the material is a set', async () => {
+    const client = {
+      from(table: string) {
+        return {
+          select() {
+            return {
+              eq() {
+                return {
+                  order: async () =>
+                    table === 'flashcards'
+                      ? {
+                          data: [{ id: 'c1', front: 'Term', back: 'Def', status: 'new' }],
+                          error: null,
+                        }
+                      : { data: [], error: null },
+                  maybeSingle: async () =>
+                    table === 'flashcard_sets'
+                      ? { data: { title: 'Cells' }, error: null }
+                      : { data: null, error: null },
+                }
+              },
+            }
+          },
+        }
+      },
+    }
+
+    const deck = await loadStudyDeck(client, 'set-1')
+    expect(deck?.source).toBe('flashcard')
+    expect(deck?.title).toBe('Cells')
+    expect(deck?.cards).toHaveLength(1)
+    expect(deck?.cards[0]?.term).toBe('Term')
+  })
+
+  it('falls back to reviewer terms so Learn/Practice work on reviewers', async () => {
+    const client = {
+      from(table: string) {
+        return {
+          select() {
+            return {
+              eq() {
+                return {
+                  order: async () => {
+                    if (table === 'flashcards') return { data: [], error: null }
+                    if (table === 'reviewer_categories') {
+                      return {
+                        data: [
+                          {
+                            id: 'cat-1',
+                            reviewer_terms: [{ id: 't1', term: 'Osmosis', definition: 'Water movement' }],
+                          },
+                        ],
+                        error: null,
+                      }
+                    }
+                    return { data: [], error: null }
+                  },
+                  maybeSingle: async () =>
+                    table === 'reviewers'
+                      ? { data: { title: 'Biology notes' }, error: null }
+                      : { data: null, error: null },
+                }
+              },
+            }
+          },
+        }
+      },
+    }
+
+    const deck = await loadStudyDeck(client, 'rev-1')
+    expect(deck?.source).toBe('reviewer')
+    expect(deck?.title).toBe('Biology notes')
+    expect(deck?.cards).toEqual([
+      { id: 't1', term: 'Osmosis', definition: 'Water movement', status: 'new', source: 'reviewer' },
+    ])
+  })
+
+  it('returns null when neither flashcards nor reviewer terms exist', async () => {
+    const client = {
+      from() {
+        return {
+          select() {
+            return {
+              eq() {
+                return {
+                  order: async () => ({ data: [], error: null }),
+                  maybeSingle: async () => ({ data: null, error: null }),
+                }
+              },
+            }
+          },
+        }
+      },
+    }
+
+    expect(await loadStudyDeck(client, 'missing')).toBeNull()
+  })
+})

--- a/src/tests/services/geminiKeys.test.ts
+++ b/src/tests/services/geminiKeys.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'bun:test'
-import { loadApiKeys } from '@/services/geminiClient'
+import { isRotatableKeyError, loadApiKeys } from '@/services/geminiClient'
 
 describe('loadApiKeys', () => {
   it('includes GEMINI_API_KEY before numbered keys and skips duplicates', () => {
@@ -18,5 +18,19 @@ describe('loadApiKeys', () => {
       GEMINI_API_KEY_5: 'five',
     } as unknown as NodeJS.ProcessEnv)
     expect(keys).toEqual(['one', 'five'])
+  })
+})
+
+describe('isRotatableKeyError', () => {
+  it('rotates past quota and dead keys', () => {
+    expect(isRotatableKeyError(new Error('429 Too Many Requests'))).toBe(true)
+    expect(isRotatableKeyError(new Error('RESOURCE_EXHAUSTED'))).toBe(true)
+    expect(isRotatableKeyError(new Error('API key not valid. Please pass a valid API key.'))).toBe(true)
+    expect(isRotatableKeyError(new Error('{"reason":"API_KEY_INVALID"}'))).toBe(true)
+  })
+
+  it('does not rotate past prompt or model errors', () => {
+    expect(isRotatableKeyError(new Error('safety filter blocked the prompt'))).toBe(false)
+    expect(isRotatableKeyError(new Error('model not found'))).toBe(false)
   })
 })


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Core-feature audit against the live DeepTerm stack (runtime secrets + local Next.js). Production schema gaps, a private-schema folder trigger, reviewer study routes, and Gemini key rotation were breaking core flows.

**Live database (additive, already applied)**
- Added `ease_factor`, `interval_days`, `repetitions`, and `due_at` on `flashcards` so dashboard due counts and SM-2 reviews persist.
- Added `public.refund_ai_usage` so failed/cancelled generations can refund quota.
- Added `practice_sessions` with RLS so practice completion can record scores.
- Made `private.folders_normalize()` `SECURITY DEFINER` so folder create/rename works. The invoker trigger could not call `private.sanitize_folder_name()` because `authenticated` has no `USAGE` on schema `private`.

**App**
- Dashboard logs query failures instead of silently rendering an empty library.
- Learn / Practice / Flashcards / Match load reviewer terms when the id is a reviewer, not only a flashcard set.
- Practice session inserts include `user_id` and skip the flashcard-set FK for reviewer decks.
- Create wizard keeps the remaining-generation count after a successful AI call.
- Gemini rotation continues past invalid API keys (placeholder `GEMINI_API_KEY` no longer blocks a valid numbered key).
- `agentRules: false` so `next dev` stops appending a generated block onto `AGENTS.md`.

## Test plan

- [x] `bun test` (737 passing)
- [x] `bunx tsc --noEmit`
- [x] Browser walkthrough: dashboard due cards, Learn answer, reviewer Learn, Practice, Match, Pomodoro, manual create, share
- [x] Folder create/rename/file a set (was 403 `permission denied for schema private`, now 201/200)
- [x] Share preview, share copy, share GET/POST
- [x] `GET /api/ai-usage` remaining 10; generate without Turnstile 403; cron without bearer 401
- [x] Gemini `generateContentWithRotation` succeeds after skipping a dead first key (Stomata + Chlorophyll)

Turnstile still failed in this Cloud Agent Chrome (`600010` / widget did not load), so the in-browser Generate button could not complete. The same Gemini client the generate routes use succeeded after the rotation fix.

[Dashboard after study with due cards and Bio folder](https://cursor.com/agents/bc-01a03d85-903d-7e29-9fcd-c32201a1c185/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdashboard_after_study.png)
[Materials library with Bio folder, copy, reviewer, and manual Stomata set](https://cursor.com/agents/bc-01a03d85-903d-7e29-9fcd-c32201a1c185/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fmaterials_library_after_audit.png)
[core_features_walkthrough_demo.mp4](https://cursor.com/agents/bc-01a03d85-903d-7e29-9fcd-c32201a1c185/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fcore_features_walkthrough_demo.mp4)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a03d85-903d-7e29-9fcd-c32201a1c185?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a03d85-903d-7e29-9fcd-c32201a1c185&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

