### PR TITLE
fix(ai): stop upload→generate failures past Vercel’s 4.5MB body limit

### DIFF
--- a/.cursor/skills/verify-deepterm/SKILL.md
+++ b/.cursor/skills/verify-deepterm/SKILL.md
@@ -1,0 +1,78 @@
+---
+name: verify-deepterm
+description: "Drive DeepTerm (Next.js study app) the way a user does — landing, auth-gated materials create, and generate APIs. Use when proving upload→AI convert, create wizard, or dashboard flows work."
+---
+
+# Verify DeepTerm
+
+Project-local control skill for agents. Read cold: this is how you launch, doctor, drive, capture evidence, and clean up without guessing.
+
+## Launch
+
+```bash
+cd /workspace
+test -f .env.local || echo "missing .env.local (Supabase + Gemini + optional Turnstile)"
+bun install
+bun run dev
+```
+
+Ready when stdout shows `Local: http://localhost:3000` (or the next free port). Default port **3000**.
+
+Teardown: kill the PID you started (from the terminal header / `lsof -i :3000`), never `pkill -f next`.
+
+## Doctor
+
+```bash
+curl -s -o /dev/null -w "%{http_code}" http://localhost:3000/
+bun -e 'import { MAX_GENERATE_UPLOAD_BYTES, VERCEL_FUNCTION_BODY_LIMIT_BYTES } from "./src/utils/generateInput.ts"; if (!(MAX_GENERATE_UPLOAD_BYTES < VERCEL_FUNCTION_BODY_LIMIT_BYTES)) process.exit(1)'
+test -n "$NEXT_PUBLIC_SUPABASE_URL" -o -f .env.local
+```
+
+Expect: home returns `200`, upload ceiling is under Vercel’s 4.5MB body limit, env present.
+
+## Drive
+
+Primary surface: **web UI** via browser/CDP (`computerUse` or Browser-use). Auth-gated paths need a signed-in session cookie.
+
+Stable entry points:
+
+| Path | Gate | Purpose |
+|------|------|---------|
+| `/` | public | Landing |
+| `/materials/create` | auth | Upload → flashcards / study guide (reviewer) |
+| `/materials` | auth | Library |
+| `POST /api/generate-cards` | auth + CSRF + Turnstile | AI flashcards |
+| `POST /api/generate-reviewer` | auth + CSRF + Turnstile | AI study guide |
+
+Create wizard selectors (prefer role/text over coordinates):
+
+- Source step: dropzone “Drag and drop your document”, “Up to 4MB”
+- Configure: Flashcards vs Reviewer / study guide
+- Generate: primary generate CTA; Captcha modal when Turnstile site key is set
+
+Without a browser session, drive the **API contract** with `bun test src/tests/api/generate-cards.integration.test.ts` and `bun test src/tests/utils/generateUploadLimits.test.ts`.
+
+Helper:
+
+```bash
+.cursor/skills/verify-deepterm/scripts/doctor.sh
+```
+
+## Evidence
+
+Store proofs under `/opt/cursor/artifacts/verify-deepterm/` (or `/tmp/verify-deepterm/` locally). Keep:
+
+1. Screenshot or video of `/materials/create` source step showing the **4MB** limit copy
+2. Test transcript proving >4MB files are rejected (`File too large`)
+3. Optional: successful text-paste generate (auth required)
+
+Proof standards: real user path when authenticated; otherwise the integration tests above. Do not treat “page compiles” as proof of upload→AI.
+
+## Cleanup
+
+Stop only the `bun run dev` / `next` process you started. Leave evidence files in place. Do not delete `/opt/cursor/artifacts/verify-deepterm/*` proofs.
+
+## Helpers
+
+- `scripts/doctor.sh` — port + limit + env sanity
+- Feature map: `features/` (index + one file per feature)

--- a/.cursor/skills/verify-deepterm/features/README.md
+++ b/.cursor/skills/verify-deepterm/features/README.md
@@ -1,0 +1,11 @@
+# DeepTerm feature map
+
+Index of user-facing features for verification. Drive each with `verify-deepterm` harness rules.
+
+| Feature | File | Auth |
+|---------|------|------|
+| Landing | `landing.md` | no |
+| Create from document | `create-from-document.md` | yes |
+| Generate flashcards API | `generate-flashcards.md` | yes |
+| Generate study guide API | `generate-reviewer.md` | yes |
+| Materials library | `materials-library.md` | yes |

--- a/.cursor/skills/verify-deepterm/features/create-from-document.md
+++ b/.cursor/skills/verify-deepterm/features/create-from-document.md
@@ -1,0 +1,31 @@
+# Create from document
+
+Auth-gated wizard at `/materials/create`: upload or paste → choose Flashcards or Study Guide → AI generate → review → save.
+
+## Sub-features
+
+- File dropzone (PDF, DOCX, PNG, JPG, WebP)
+- Paste text / manual entry
+- Turnstile captcha when configured
+- Draft restore via sessionStorage (file blob cannot restore)
+
+## How to get to it (user POV)
+
+Sign in → Materials → Create, or `/materials/create`.
+
+## Driving it with verify-deepterm
+
+1. Authenticated browser session
+2. Open `/materials/create`
+3. Confirm copy says **Up to 4MB**
+4. Upload a small PDF/DOCX or paste text
+5. Choose Flashcards or Reviewer, run Generate
+6. Expect review step with cards/sections
+
+Without auth: run `bun test src/tests/utils/generateUploadLimits.test.ts` and the generate-cards integration suite.
+
+## Gotchas
+
+- Vercel Function body limit is **4.5MB**; uploads above ~4MB fail with 413 in production if the UI allowed them
+- After refresh, a restored file name without a live `File` must force re-select
+- Reviewer and flashcards share the same 4MB upload ceiling

--- a/.cursor/skills/verify-deepterm/features/generate-flashcards.md
+++ b/.cursor/skills/verify-deepterm/features/generate-flashcards.md
@@ -1,0 +1,25 @@
+# Generate flashcards API
+
+`POST /api/generate-cards` turns text or a document into `{ cards: [{ term, definition }] }`.
+
+## Sub-features
+
+- MIME allowlist + size guard
+- DOCX via mammoth; PDF/images via Gemini Files API
+- Daily AI quota + Turnstile + same-origin CSRF
+
+## How to get to it (user POV)
+
+Create wizard → Flashcards → Generate.
+
+## Driving it with verify-deepterm
+
+```bash
+bun test src/tests/api/generate-cards.integration.test.ts
+```
+
+Expect: >4MB file → 400 `File too large`; valid text → 200 with cards (mocked Gemini in tests).
+
+## Gotchas
+
+`maxDuration` is 90s. Client aborts at 90s. Do not raise upload size without a Blob/direct-to-Gemini path around Vercel’s 4.5MB body cap.

--- a/.cursor/skills/verify-deepterm/features/generate-reviewer.md
+++ b/.cursor/skills/verify-deepterm/features/generate-reviewer.md
@@ -1,0 +1,20 @@
+# Generate study guide API
+
+`POST /api/generate-reviewer` turns text or a document into categorized terms (`extractionMode`: full | sentence | keywords).
+
+## Sub-features
+
+- Same upload ceiling as flashcards (4MB)
+- Exhaustive extraction prompt
+
+## How to get to it (user POV)
+
+Create wizard → Reviewer / study guide → pick extraction mode → Generate.
+
+## Driving it with verify-deepterm
+
+Prefer UI path when signed in. Contract checks: shared `MAX_REVIEWER_FILE_SIZE` === `MAX_GENERATE_UPLOAD_BYTES` via `generateUploadLimits` tests.
+
+## Gotchas
+
+Users may call this “AI slides” or “squeeze”; product name is study guide / reviewer.

--- a/.cursor/skills/verify-deepterm/features/landing.md
+++ b/.cursor/skills/verify-deepterm/features/landing.md
@@ -1,0 +1,20 @@
+# Landing
+
+Public marketing home at `/`.
+
+## Sub-features
+
+- Hero CTA into sign-in / study
+- FAQ describing PDF/DOCX upload
+
+## How to get to it (user POV)
+
+Open `https://deepterm.app/` or `http://localhost:3000/`.
+
+## Driving it with verify-deepterm
+
+Browser navigate to `/`. Expect HTTP 200 and a visible product name / study CTA. No auth.
+
+## Gotchas
+
+`www.deepterm.app` redirects to apex/www pair; stay on trusted origins only.

--- a/.cursor/skills/verify-deepterm/features/materials-library.md
+++ b/.cursor/skills/verify-deepterm/features/materials-library.md
@@ -1,0 +1,20 @@
+# Materials library
+
+Auth-gated `/materials` lists saved flashcard sets and reviewers; open detail for study/practice.
+
+## Sub-features
+
+- Folders, rename, delete, share
+- Practice tests built client-side from cards (not from upload)
+
+## How to get to it (user POV)
+
+Sign in → Materials in sidebar.
+
+## Driving it with verify-deepterm
+
+Browser: `/materials` after auth. Empty state should offer Create.
+
+## Gotchas
+
+Soft-deleted accounts are restricted by `src/proxy.ts` to `/`, `/auth`, `/account`.

--- a/.cursor/skills/verify-deepterm/scripts/doctor.sh
+++ b/.cursor/skills/verify-deepterm/scripts/doctor.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+set -euo pipefail
+ROOT="$(cd "$(dirname "$0")/../../../.." && pwd)"
+cd "$ROOT"
+
+code="$(curl -s -o /dev/null -w "%{http_code}" http://localhost:3000/ || true)"
+if [[ "$code" != "200" ]]; then
+  echo "doctor: home not ready (HTTP $code). Start with: bun run dev"
+  exit 1
+fi
+
+bun -e '
+import {
+  MAX_GENERATE_UPLOAD_BYTES,
+  VERCEL_FUNCTION_BODY_LIMIT_BYTES,
+} from "./src/utils/generateInput.ts"
+if (!(MAX_GENERATE_UPLOAD_BYTES < VERCEL_FUNCTION_BODY_LIMIT_BYTES)) {
+  console.error("doctor: upload ceiling exceeds Vercel body limit")
+  process.exit(1)
+}
+console.log("doctor: upload ceiling", MAX_GENERATE_UPLOAD_BYTES, "<", VERCEL_FUNCTION_BODY_LIMIT_BYTES)
+'
+
+if [[ ! -f .env.local ]] && [[ -z "${NEXT_PUBLIC_SUPABASE_URL:-}" ]]; then
+  echo "doctor: missing Supabase env"
+  exit 1
+fi
+
+echo "doctor: ok"

--- a/bun.lock
+++ b/bun.lock
@@ -60,6 +60,9 @@
       "minimatch": "9.0.9",
     },
     "brace-expansion": "1.1.18",
+    "docx": {
+      "nanoid": "5.1.16",
+    },
     "dompurify": "3.4.14",
     "flatted": "3.4.4",
     "glob": {
@@ -75,7 +78,7 @@
     "picomatch": "4.0.7",
     "postcss": {
       ".": "^8.5.12",
-      "nanoid": "3.3.11",
+      "nanoid": "3.3.18",
     },
     "protobufjs": "7.6.5",
     "ws": "8.21.3",
@@ -1491,7 +1494,7 @@
 
     "path-scurry/lru-cache": ["lru-cache@10.4.3", "", {}, "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ=="],
 
-    "postcss/nanoid": ["nanoid@3.3.11", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w=="],
+    "postcss/nanoid": ["nanoid@3.3.18", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w=="],
 
     "posthog-js/core-js": ["core-js@3.50.0", "", {}, "sha512-BRWgOLKkFeCgRudR6zrs8p9XJZcE14grzKMMssoYrk6krtuEZ7MTKPIY5RzOnqsEKIR9kst7wNzphttraT+Yqw=="],
 

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "minimatch@9": "9.0.9",
     "postcss": {
       ".": "^8.5.12",
-      "nanoid": "3.3.11"
+      "nanoid": "3.3.18"
     },
     "micromatch": {
       "picomatch": "2.3.2"

--- a/src/app/(dashboard)/materials/create/StepSource.tsx
+++ b/src/app/(dashboard)/materials/create/StepSource.tsx
@@ -159,7 +159,7 @@ export function StepSource({
                 Drag and drop your document here, or <span className="text-brand underline underline-offset-4">browse</span>
               </p>
               <p className="caption text-muted">
-                PDF, DOCX, PNG, JPG, or WebP &middot; Up to 20MB &middot; Or paste file from clipboard
+                PDF, DOCX, PNG, JPG, or WebP &middot; Up to 4MB &middot; Or paste file from clipboard
               </p>
             </div>
           </div>

--- a/src/app/(dashboard)/materials/create/page.tsx
+++ b/src/app/(dashboard)/materials/create/page.tsx
@@ -277,7 +277,7 @@ export default function CreateMaterialPage() {
                 variant="primary"
                 size="lg"
                 disabled={
-                  (sourceMethod === 'file' && !selectedFile && !fileSummary) ||
+                  (sourceMethod === 'file' && !selectedFile) ||
                   (sourceMethod === 'text' && !pastedText.trim()) ||
                   !title.trim()
                 }

--- a/src/app/(dashboard)/materials/create/useCreateDraft.ts
+++ b/src/app/(dashboard)/materials/create/useCreateDraft.ts
@@ -6,6 +6,13 @@ import { createClient } from '@/config/supabase/client';
 import { fetchFolders, createFolder, type SupabaseLike } from '@/lib/folders/api';
 import type { Folder } from '@/lib/schemas/materials';
 import { buildReviewerInsertPayloads } from '@/utils/reviewerBatch';
+import {
+  MAX_GENERATE_UPLOAD_BYTES,
+  maxUploadMegabytesLabel,
+  missingUploadFileMessage,
+  requiresLiveFileForGenerate,
+} from '@/utils/generateInput';
+import { CLIENT_GENERATION_TIMEOUT_MS } from '@/utils/abort';
 import { generateItemId } from './parseBulkText';
 import type {
   WizardStep,
@@ -20,7 +27,8 @@ import type {
 const DRAFT_STORAGE_KEY = 'deepterm_create_draft_v1';
 export const ACCEPTED_FILE_EXTENSIONS = ['pdf', 'docx', 'png', 'jpg', 'jpeg', 'webp'];
 export const ACCEPTED_FILE_TYPES_ATTR = '.pdf,.docx,.png,.jpg,.jpeg,.webp';
-export const MAX_FILE_SIZE = 20 * 1024 * 1024; // 20MB
+export const MAX_FILE_SIZE = MAX_GENERATE_UPLOAD_BYTES;
+export const MAX_FILE_SIZE_LABEL = maxUploadMegabytesLabel(MAX_FILE_SIZE);
 
 interface ApiCategory {
   name: string;
@@ -114,12 +122,8 @@ export function useCreateDraft() {
       if (saved) {
         const parsed = JSON.parse(saved) as StoredDraft;
         if (parsed) {
-          if (parsed.wizardStep) setWizardStep(parsed.wizardStep);
           if (parsed.sourceMethod) setSourceMethod(parsed.sourceMethod);
           if (parsed.pastedText) setPastedText(parsed.pastedText);
-          if (parsed.fileName && parsed.fileSize) {
-            setFileSummary({ name: parsed.fileName, size: parsed.fileSize, type: 'file' });
-          }
           if (parsed.targetType) setTargetType(parsed.targetType);
           if (parsed.extractionMode) setExtractionMode(parsed.extractionMode);
           if (parsed.title) setTitle(parsed.title);
@@ -129,6 +133,29 @@ export function useCreateDraft() {
             setReviewerCategories(parsed.reviewerCategories);
           }
           if (parsed.generatedFrom) setGeneratedFrom(parsed.generatedFrom);
+
+          const restoredHasContent =
+            Boolean(parsed.generatedFrom) ||
+            Boolean(parsed.cards?.some((c) => c.term.trim() || c.definition.trim())) ||
+            Boolean(parsed.reviewerCategories && parsed.reviewerCategories.length > 0);
+
+          // File blobs cannot survive sessionStorage. Keep the name for display only
+          // after a successful generate; otherwise force a fresh upload.
+          if (parsed.fileName && parsed.fileSize && restoredHasContent) {
+            setFileSummary({ name: parsed.fileName, size: parsed.fileSize, type: 'file' });
+          }
+
+          if (parsed.wizardStep) {
+            if (
+              parsed.sourceMethod === 'file' &&
+              !restoredHasContent &&
+              parsed.wizardStep === 'configure'
+            ) {
+              setWizardStep('source');
+            } else {
+              setWizardStep(parsed.wizardStep);
+            }
+          }
         }
       }
     } catch {
@@ -202,7 +229,9 @@ export function useCreateDraft() {
   const handleFileSelect = (file: File) => {
     setError(null);
     if (file.size > MAX_FILE_SIZE) {
-      setError(`File size exceeds 20MB limit (${(file.size / 1024 / 1024).toFixed(1)}MB)`);
+      setError(
+        `File size exceeds ${MAX_FILE_SIZE_LABEL} limit (${(file.size / 1024 / 1024).toFixed(1)}MB). Larger files cannot be sent through the generate API.`,
+      );
       return false;
     }
 
@@ -254,7 +283,7 @@ export function useCreateDraft() {
 
   // Step 1 -> Step 2 validation
   const canContinueToConfigure = () => {
-    if (sourceMethod === 'file') return Boolean(selectedFile || fileSummary);
+    if (sourceMethod === 'file') return Boolean(selectedFile);
     if (sourceMethod === 'text') return Boolean(pastedText.trim().length > 0);
     if (sourceMethod === 'manual') return true;
     return false;
@@ -372,13 +401,21 @@ export function useCreateDraft() {
       return;
     }
 
-    if (sourceMethod === 'file' && !selectedFile && !fileSummary) {
-      setError('Please select a file to generate from.');
+    if (sourceMethod === 'file' && requiresLiveFileForGenerate(selectedFile)) {
+      setError(missingUploadFileMessage());
+      setWizardStep('source');
       return;
     }
 
     if (sourceMethod === 'text' && !pastedText.trim()) {
       setError('Please paste text to generate from.');
+      return;
+    }
+
+    if (sourceMethod === 'file' && selectedFile && selectedFile.size > MAX_FILE_SIZE) {
+      setError(
+        `File size exceeds ${MAX_FILE_SIZE_LABEL} limit (${(selectedFile.size / 1024 / 1024).toFixed(1)}MB).`,
+      );
       return;
     }
 
@@ -389,7 +426,7 @@ export function useCreateDraft() {
     abortControllerRef.current = controller;
     const timeoutId = setTimeout(() => {
       controller.abort();
-    }, 90000); // 90 second timeout
+    }, CLIENT_GENERATION_TIMEOUT_MS);
 
     try {
       const supabase = createClient();
@@ -399,7 +436,10 @@ export function useCreateDraft() {
       }
 
       const formData = new FormData();
-      if (sourceMethod === 'file' && selectedFile) {
+      if (sourceMethod === 'file') {
+        if (!selectedFile) {
+          throw new Error(missingUploadFileMessage());
+        }
         formData.append('file', selectedFile);
       } else if (sourceMethod === 'text') {
         formData.append('textContent', pastedText);

--- a/src/app/api/generate-cards/route.ts
+++ b/src/app/api/generate-cards/route.ts
@@ -12,9 +12,17 @@ import {
   resolveGenerateMimeType,
 } from "@/utils/generateInput";
 import { GeminiCardsResponseSchema } from "@/lib/schemas/geminiOutput";
-import { combineAbortSignals, GENERATION_TIMEOUT_MS, isAbortError, throwIfAborted } from "@/utils/abort";
+import {
+  combineAbortSignals,
+  GENERATION_MAX_DURATION_SECONDS,
+  GENERATION_TIMEOUT_MS,
+  isAbortError,
+  throwIfAborted,
+} from "@/utils/abort";
 import { z } from "zod";
 import { forbiddenUnlessSameOrigin } from "@/lib/auth/assertSameOrigin";
+
+export const maxDuration = GENERATION_MAX_DURATION_SECONDS;
 
 const MAX_FILE_SIZE = MAX_CARDS_FILE_SIZE;
 const MAX_TEXT_LENGTH = MAX_GENERATE_TEXT_LENGTH;
@@ -220,6 +228,11 @@ MANDATORY:
         responseSchema: flashcardResponseSchema,
       },
     });
+
+    if (!responseText.trim()) {
+      await refundAIGeneration();
+      return NextResponse.json({ error: "AI returned empty response. Please try again." }, { status: 500 });
+    }
 
     let parsedJson: unknown;
     try {

--- a/src/app/api/generate-cards/route.ts
+++ b/src/app/api/generate-cards/route.ts
@@ -14,7 +14,6 @@ import {
 import { GeminiCardsResponseSchema } from "@/lib/schemas/geminiOutput";
 import {
   combineAbortSignals,
-  GENERATION_MAX_DURATION_SECONDS,
   GENERATION_TIMEOUT_MS,
   isAbortError,
   throwIfAborted,
@@ -22,7 +21,7 @@ import {
 import { z } from "zod";
 import { forbiddenUnlessSameOrigin } from "@/lib/auth/assertSameOrigin";
 
-export const maxDuration = GENERATION_MAX_DURATION_SECONDS;
+export const maxDuration = 90;
 
 const MAX_FILE_SIZE = MAX_CARDS_FILE_SIZE;
 const MAX_TEXT_LENGTH = MAX_GENERATE_TEXT_LENGTH;

--- a/src/app/api/generate-reviewer/route.ts
+++ b/src/app/api/generate-reviewer/route.ts
@@ -12,8 +12,16 @@ import {
   resolveGenerateMimeType,
 } from "@/utils/generateInput";
 import { GeminiReviewerResponseSchema } from "@/lib/schemas/geminiOutput";
-import { combineAbortSignals, GENERATION_TIMEOUT_MS, isAbortError, throwIfAborted } from "@/utils/abort";
+import {
+  combineAbortSignals,
+  GENERATION_MAX_DURATION_SECONDS,
+  GENERATION_TIMEOUT_MS,
+  isAbortError,
+  throwIfAborted,
+} from "@/utils/abort";
 import { forbiddenUnlessSameOrigin } from "@/lib/auth/assertSameOrigin";
+
+export const maxDuration = GENERATION_MAX_DURATION_SECONDS;
 
 const MAX_FILE_SIZE = MAX_REVIEWER_FILE_SIZE;
 const MAX_TEXT_LENGTH = MAX_GENERATE_TEXT_LENGTH;

--- a/src/app/api/generate-reviewer/route.ts
+++ b/src/app/api/generate-reviewer/route.ts
@@ -14,14 +14,13 @@ import {
 import { GeminiReviewerResponseSchema } from "@/lib/schemas/geminiOutput";
 import {
   combineAbortSignals,
-  GENERATION_MAX_DURATION_SECONDS,
   GENERATION_TIMEOUT_MS,
   isAbortError,
   throwIfAborted,
 } from "@/utils/abort";
 import { forbiddenUnlessSameOrigin } from "@/lib/auth/assertSameOrigin";
 
-export const maxDuration = GENERATION_MAX_DURATION_SECONDS;
+export const maxDuration = 90;
 
 const MAX_FILE_SIZE = MAX_REVIEWER_FILE_SIZE;
 const MAX_TEXT_LENGTH = MAX_GENERATE_TEXT_LENGTH;

--- a/src/tests/api/generate-cards.integration.test.ts
+++ b/src/tests/api/generate-cards.integration.test.ts
@@ -234,8 +234,8 @@ describe('POST /api/generate-cards', () => {
     })
 
     it('should return 400 for files exceeding size limit', async () => {
-      // Create a file larger than 20MB
-      const largeContent = new Uint8Array(21 * 1024 * 1024) // 21MB
+      // Create a file larger than the generate upload ceiling (Vercel body limit headroom)
+      const largeContent = new Uint8Array(5 * 1024 * 1024) // 5MB
       const largeFile = new File([largeContent], 'large.pdf', { type: 'application/pdf' })
       
       const request = createFormDataRequest({ file: largeFile })

--- a/src/tests/utils/generateInput.test.ts
+++ b/src/tests/utils/generateInput.test.ts
@@ -34,5 +34,6 @@ describe('generateInput', () => {
     expect(isGenerateFileTooLarge(MAX_CARDS_FILE_SIZE, MAX_CARDS_FILE_SIZE)).toBe(false)
     expect(MAX_GENERATE_TEXT_LENGTH).toBe(100000)
     expect(isDocxMime(DOCX_MIME_TYPE)).toBe(true)
+    expect(MAX_CARDS_FILE_SIZE).toBe(4 * 1024 * 1024)
   })
 })

--- a/src/tests/utils/generateUploadLimits.test.ts
+++ b/src/tests/utils/generateUploadLimits.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from 'bun:test'
+import {
+  MAX_CARDS_FILE_SIZE,
+  MAX_REVIEWER_FILE_SIZE,
+  MAX_GENERATE_UPLOAD_BYTES,
+  VERCEL_FUNCTION_BODY_LIMIT_BYTES,
+  maxUploadBytesForTarget,
+  missingUploadFileMessage,
+  requiresLiveFileForGenerate,
+} from '@/utils/generateInput'
+import {
+  CLIENT_GENERATION_TIMEOUT_MS,
+  GENERATION_MAX_DURATION_SECONDS,
+  GENERATION_TIMEOUT_MS,
+} from '@/utils/abort'
+
+describe('generate upload limits vs Vercel body ceiling', () => {
+  it('keeps every advertised upload limit under the 4.5MB function body cap', () => {
+    expect(VERCEL_FUNCTION_BODY_LIMIT_BYTES).toBe(4.5 * 1024 * 1024)
+    expect(MAX_GENERATE_UPLOAD_BYTES).toBeLessThanOrEqual(4 * 1024 * 1024)
+    expect(MAX_CARDS_FILE_SIZE).toBe(MAX_GENERATE_UPLOAD_BYTES)
+    expect(MAX_REVIEWER_FILE_SIZE).toBe(MAX_GENERATE_UPLOAD_BYTES)
+    expect(MAX_CARDS_FILE_SIZE).toBeLessThan(VERCEL_FUNCTION_BODY_LIMIT_BYTES)
+    expect(MAX_REVIEWER_FILE_SIZE).toBeLessThan(VERCEL_FUNCTION_BODY_LIMIT_BYTES)
+  })
+
+  it('uses one shared upload ceiling for flashcards and reviewers', () => {
+    expect(maxUploadBytesForTarget('material')).toBe(MAX_GENERATE_UPLOAD_BYTES)
+    expect(maxUploadBytesForTarget('reviewer')).toBe(MAX_GENERATE_UPLOAD_BYTES)
+  })
+
+  it('rejects a 15MB file that the old UI incorrectly allowed', () => {
+    const fifteenMb = 15 * 1024 * 1024
+    expect(fifteenMb).toBeGreaterThan(MAX_GENERATE_UPLOAD_BYTES)
+    expect(fifteenMb).toBeGreaterThan(VERCEL_FUNCTION_BODY_LIMIT_BYTES)
+  })
+})
+
+describe('ghost file session restore', () => {
+  it('requires a live File blob before generate, not a restored summary', () => {
+    expect(requiresLiveFileForGenerate(null)).toBe(true)
+    expect(requiresLiveFileForGenerate(new File(['x'], 'notes.pdf', { type: 'application/pdf' }))).toBe(false)
+    expect(missingUploadFileMessage()).toContain('re-select')
+  })
+})
+
+describe('generation duration budget', () => {
+  it('keeps app timeouts inside the declared Vercel maxDuration window', () => {
+    expect(GENERATION_MAX_DURATION_SECONDS).toBeGreaterThanOrEqual(90)
+    expect(GENERATION_TIMEOUT_MS).toBeLessThan(GENERATION_MAX_DURATION_SECONDS * 1000)
+    expect(CLIENT_GENERATION_TIMEOUT_MS).toBeGreaterThan(GENERATION_TIMEOUT_MS)
+    expect(CLIENT_GENERATION_TIMEOUT_MS).toBeLessThanOrEqual(GENERATION_MAX_DURATION_SECONDS * 1000)
+  })
+})

--- a/src/utils/abort.ts
+++ b/src/utils/abort.ts
@@ -1,4 +1,11 @@
+/** Declared Vercel maxDuration for generate routes (seconds). */
+export const GENERATION_MAX_DURATION_SECONDS = 90
+
+/** Server-side AbortSignal budget; must stay under maxDuration. */
 export const GENERATION_TIMEOUT_MS = 85_000
+
+/** Browser fetch abort; slightly above server budget, within maxDuration. */
+export const CLIENT_GENERATION_TIMEOUT_MS = 90_000
 
 export function isAbortError(error: unknown): boolean {
   if (error instanceof DOMException && error.name === 'AbortError') return true

--- a/src/utils/generateInput.ts
+++ b/src/utils/generateInput.ts
@@ -16,9 +16,37 @@ export const GEMINI_UPLOAD_MIME_TYPES = [
   'image/webp',
 ] as const
 
-export const MAX_CARDS_FILE_SIZE = 20 * 1024 * 1024
-export const MAX_REVIEWER_FILE_SIZE = 10 * 1024 * 1024
+/** Hard Vercel Function request/response body ceiling (FUNCTION_PAYLOAD_TOO_LARGE). */
+export const VERCEL_FUNCTION_BODY_LIMIT_BYTES = 4.5 * 1024 * 1024
+
+/**
+ * Safe multipart upload ceiling for /api/generate-*.
+ * Leave headroom under 4.5MB for FormData boundaries and Turnstile fields.
+ */
+export const MAX_GENERATE_UPLOAD_BYTES = 4 * 1024 * 1024
+
+export const MAX_CARDS_FILE_SIZE = MAX_GENERATE_UPLOAD_BYTES
+export const MAX_REVIEWER_FILE_SIZE = MAX_GENERATE_UPLOAD_BYTES
 export const MAX_GENERATE_TEXT_LENGTH = 100000
+
+export type GenerateTargetType = 'material' | 'reviewer'
+
+export function maxUploadBytesForTarget(target: GenerateTargetType): number {
+  void target
+  return MAX_GENERATE_UPLOAD_BYTES
+}
+
+export function maxUploadMegabytesLabel(bytes: number = MAX_GENERATE_UPLOAD_BYTES): string {
+  return `${Math.round(bytes / (1024 * 1024))}MB`
+}
+
+export function requiresLiveFileForGenerate(selectedFile: File | null): boolean {
+  return selectedFile == null
+}
+
+export function missingUploadFileMessage(): string {
+  return 'Your document is no longer available in this browser session. Please re-select the file to generate.'
+}
 
 const EXTENSION_MIME: Record<string, string> = {
   pdf: 'application/pdf',


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Document upload → AI flashcards / study guide failed for many real lecture PDFs.

**Root cause (reproduced):** Vercel Functions hard-cap request bodies at **4.5MB** (`FUNCTION_PAYLOAD_TOO_LARGE`). The UI allowed **20MB** and the APIs allowed **10–20MB**, so the client sent payloads the platform rejects before our handlers run.

**Also found:**
1. After refresh, `sessionStorage` restored a file *name* without a live `File`, so Generate posted empty FormData → “No file or text content provided”.
2. Generate routes had no declared `maxDuration` while the app waited 85–90s. An imported `maxDuration` also broke the Next.js production build until switched to a literal.
3. Flashcards vs reviewer size limits disagreed (20 vs 10).

## Fix

- Cap generate uploads at **4MB** (shared client + both APIs), under the 4.5MB ceiling with multipart headroom.
- Require a live `File` before continue/generate; don’t pretend a restored summary is uploadable.
- Export literal `maxDuration = 90` on both generate routes.
- Clearer empty-AI handling on generate-cards; pin `postcss`→`nanoid@3.3.18` so `bun audit` is clean.
- Add `.cursor/skills/verify-deepterm` for agent-driven verification.

## Verification

```text
bun test                     # 742 pass
bun audit                    # 0 vulnerabilities
bun run build                # succeeds
.cursor/skills/verify-deepterm/scripts/doctor.sh  # ok
```

CI on this PR (head `4cd2c6f`): CodeQL ✅ · Vercel ✅ (`dpl_Aw6pN8yndCCStzDYn9E2ACskB2Hn` READY)

## Notes for review

Larger-than-4MB docs still need a direct-to-storage / Gemini Files path later. This PR makes the advertised limit match what production can actually accept.

Product names: there is no separate “AI slides / squeeze” feature. Upload converts to **flashcards** or a **study guide (reviewer)**.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a05924-e4fe-7d8e-9ea4-27834b8ac5b7?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a05924-e4fe-7d8e-9ea4-27834b8ac5b7&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

