### PR TITLE
fix: Turnstile empty state, achievements, /login 404, AI refund RPC

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -55,15 +55,15 @@
   },
   "overrides": {
     "@babel/core": "7.29.7",
+    "@humanfs/node": "0.16.8",
     "@protobufjs/utf8": "1.1.2",
     "@typescript-eslint/typescript-estree": {
       "minimatch": "9.0.9",
     },
     "brace-expansion": "1.1.18",
-    "docx": {
-      "nanoid": "5.1.16",
-    },
+    "browserslist": "4.28.7",
     "dompurify": "3.4.14",
+    "fflate": "0.8.3",
     "flatted": "3.4.4",
     "glob": {
       "minimatch": "9.0.9",
@@ -160,9 +160,11 @@
 
     "@gsap/react": ["@gsap/react@2.1.2", "", { "peerDependencies": { "gsap": "^3.12.5", "react": ">=17" } }, "sha512-JqliybO1837UcgH2hVOM4VO+38APk3ECNrsuSM4MuXp+rbf+/2IG2K1YJiqfTcXQHH7XlA0m3ykniFYstfq0Iw=="],
 
-    "@humanfs/core": ["@humanfs/core@0.19.1", "", {}, "sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA=="],
+    "@humanfs/core": ["@humanfs/core@0.19.2", "", { "dependencies": { "@humanfs/types": "^0.15.0" } }, "sha512-UhXNm+CFMWcbChXywFwkmhqjs3PRCmcSa/hfBgLIb7oQ5HNb1wS0icWsGtSAUNgefHeI+eBrA8I1fxmbHsGdvA=="],
 
-    "@humanfs/node": ["@humanfs/node@0.16.7", "", { "dependencies": { "@humanfs/core": "^0.19.1", "@humanwhocodes/retry": "^0.4.0" } }, "sha512-/zUx+yOsIrG4Y43Eh2peDeKCxlRt/gET6aHfaKpuq267qXdYDFViVHfMaLyygZOnl0kGWxFIgsBy8QFuTLUXEQ=="],
+    "@humanfs/node": ["@humanfs/node@0.16.8", "", { "dependencies": { "@humanfs/core": "^0.19.2", "@humanfs/types": "^0.15.0", "@humanwhocodes/retry": "^0.4.0" } }, "sha512-gE1eQNZ3R++kTzFUpdGlpmy8kDZD/MLyHqDwqjkVQI0JMdI1D51sy1H958PNXYkM2rAac7e5/CnIKZrHtPh3BQ=="],
+
+    "@humanfs/types": ["@humanfs/types@0.15.0", "", {}, "sha512-ZZ1w0aoQkwuUuC7Yf+7sdeaNfqQiiLcSRbfI08oAxqLtpXQr9AIVX7Ay7HLDuiLYAaFPu8oBYNq/QIi9URHJ3Q=="],
 
     "@humanwhocodes/module-importer": ["@humanwhocodes/module-importer@1.0.1", "", {}, "sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA=="],
 
@@ -600,7 +602,7 @@
 
     "braces": ["braces@3.0.3", "", { "dependencies": { "fill-range": "^7.1.1" } }, "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA=="],
 
-    "browserslist": ["browserslist@4.28.0", "", { "dependencies": { "baseline-browser-mapping": "^2.8.25", "caniuse-lite": "^1.0.30001754", "electron-to-chromium": "^1.5.249", "node-releases": "^2.0.27", "update-browserslist-db": "^1.1.4" }, "bin": "cli.js" }, "sha512-tbydkR/CxfMwelN0vwdP/pLkDwyAASZ+VfWm4EOwlB6SWhx1sYnWLqo8N5j0rAzPfzfRaxt0mM/4wPU/Su84RQ=="],
+    "browserslist": ["browserslist@4.28.7", "", { "dependencies": { "baseline-browser-mapping": "^2.10.44", "caniuse-lite": "^1.0.30001806", "electron-to-chromium": "^1.5.393", "node-releases": "^2.0.51", "update-browserslist-db": "^1.2.3" }, "bin": { "browserslist": "cli.js" } }, "sha512-JxV13hNrFxqjOc8alRbq9dK1MM79NEXYpma2B2J4wAtpWS5zIEIKqWPGCl7N4o7Uc7B7itylh7SuDujATRyyTw=="],
 
     "buffer": ["buffer@6.0.3", "", { "dependencies": { "base64-js": "^1.3.1", "ieee754": "^1.2.1" } }, "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA=="],
 
@@ -694,7 +696,7 @@
 
     "eciesjs": ["eciesjs@0.5.0", "", { "dependencies": { "@ecies/ciphers": "^0.2.6", "@noble/ciphers": "^1.3.0", "@noble/curves": "^1.9.7", "@noble/hashes": "^1.8.0" } }, "sha512-s0J9SEVYAEPg7J63GFMApLYzPH9VNIQIyC6s15JpnqVc0TqcKWdbgFlnAweEBRyMmko2dcs2sfC83Hj4J43tuA=="],
 
-    "electron-to-chromium": ["electron-to-chromium@1.5.259", "", {}, "sha512-I+oLXgpEJzD6Cwuwt1gYjxsDmu/S/Kd41mmLA3O+/uH2pFRO/DvOjUyGozL8j3KeLV6WyZ7ssPwELMsXCcsJAQ=="],
+    "electron-to-chromium": ["electron-to-chromium@1.5.422", "", {}, "sha512-UvA/32XqrLDdZSn7Jllo1AYNcWji/G0d5M0GTViE7KoGBiMunw3a34Sb2KO4ZZyrSEhqsxFoVhWWJshdyfKqJA=="],
 
     "emoji-regex": ["emoji-regex@9.2.2", "", {}, "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg=="],
 
@@ -772,7 +774,7 @@
 
     "fetch-blob": ["fetch-blob@3.2.0", "", { "dependencies": { "node-domexception": "^1.0.0", "web-streams-polyfill": "^3.0.3" } }, "sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ=="],
 
-    "fflate": ["fflate@0.8.2", "", {}, "sha512-cPJU47OaAoCbg0pBvzsgpTPhmhqI5eJjh/JIu8tPj5q+T7iLvW/JAYUqmE7KOB4R1ZyEhzBaIQpQpardBF5z8A=="],
+    "fflate": ["fflate@0.8.3", "", {}, "sha512-tbZNuJrLwGUp3zshBtdy4W+ORxZuIh8a5ilyIEQDC5rY1f3U20JMry0Ll3WBzU58EZKsEuJFXhb5gwv8CsPvgA=="],
 
     "file-entry-cache": ["file-entry-cache@8.0.0", "", { "dependencies": { "flat-cache": "^4.0.0" } }, "sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ=="],
 
@@ -1078,7 +1080,7 @@
 
     "node-fetch": ["node-fetch@3.3.2", "", { "dependencies": { "data-uri-to-buffer": "^4.0.0", "fetch-blob": "^3.1.4", "formdata-polyfill": "^4.0.10" } }, "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA=="],
 
-    "node-releases": ["node-releases@2.0.27", "", {}, "sha512-nmh3lCkYZ3grZvqcCH+fjmQ7X+H0OeZgP40OierEaAptX4XofMh5kwNbWh7lBduUzCcV/8kZ+NDLCwm2iorIlA=="],
+    "node-releases": ["node-releases@2.0.54", "", {}, "sha512-YHs7BmmcsdAI5Ozuf8JZo6PT0mv2GIWC9vMfvUC3dp65M8hn7Ux8CPL+2oBI7juNuj9d0ndhTcznq2ODBps9cQ=="],
 
     "object-assign": ["object-assign@4.1.1", "", {}, "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg=="],
 
@@ -1344,7 +1346,7 @@
 
     "unrs-resolver": ["unrs-resolver@1.11.1", "", { "dependencies": { "napi-postinstall": "^0.3.0" }, "optionalDependencies": { "@unrs/resolver-binding-android-arm-eabi": "1.11.1", "@unrs/resolver-binding-android-arm64": "1.11.1", "@unrs/resolver-binding-darwin-arm64": "1.11.1", "@unrs/resolver-binding-darwin-x64": "1.11.1", "@unrs/resolver-binding-freebsd-x64": "1.11.1", "@unrs/resolver-binding-linux-arm-gnueabihf": "1.11.1", "@unrs/resolver-binding-linux-arm-musleabihf": "1.11.1", "@unrs/resolver-binding-linux-arm64-gnu": "1.11.1", "@unrs/resolver-binding-linux-arm64-musl": "1.11.1", "@unrs/resolver-binding-linux-ppc64-gnu": "1.11.1", "@unrs/resolver-binding-linux-riscv64-gnu": "1.11.1", "@unrs/resolver-binding-linux-riscv64-musl": "1.11.1", "@unrs/resolver-binding-linux-s390x-gnu": "1.11.1", "@unrs/resolver-binding-linux-x64-gnu": "1.11.1", "@unrs/resolver-binding-linux-x64-musl": "1.11.1", "@unrs/resolver-binding-wasm32-wasi": "1.11.1", "@unrs/resolver-binding-win32-arm64-msvc": "1.11.1", "@unrs/resolver-binding-win32-ia32-msvc": "1.11.1", "@unrs/resolver-binding-win32-x64-msvc": "1.11.1" } }, "sha512-bSjt9pjaEBnNiGgc9rUiHGKv5l4/TGzDmYw3RhnkJGtLhbnnA/5qJj7x3dNDCRx/PJxu774LlH8lCOlB4hEfKg=="],
 
-    "update-browserslist-db": ["update-browserslist-db@1.1.4", "", { "dependencies": { "escalade": "^3.2.0", "picocolors": "^1.1.1" }, "peerDependencies": { "browserslist": ">= 4.21.0" }, "bin": "cli.js" }, "sha512-q0SPT4xyU84saUX+tomz1WLkxUbuaJnR1xWt17M7fJtEJigJeWUNGUqrauFXsHnqev9y9JTRGwk13tFBuKby4A=="],
+    "update-browserslist-db": ["update-browserslist-db@1.3.2", "", { "dependencies": { "escalade": "^3.2.0", "picocolors": "^1.1.1" }, "peerDependencies": { "browserslist": ">= 4.21.0" }, "bin": { "update-browserslist-db": "cli.js" } }, "sha512-UQ+MSxlhRm1bzjhU+DcuXfjFO1FzNtqhK5+9Yvlp90ItDLk5vT932A0rFu619nf7RVS+Y/VeaUW1jaRDqZ8VJw=="],
 
     "uri-js": ["uri-js@4.4.1", "", { "dependencies": { "punycode": "^2.1.0" } }, "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg=="],
 
@@ -1464,7 +1466,7 @@
 
     "@typescript-eslint/utils/@eslint-community/eslint-utils": ["@eslint-community/eslint-utils@4.9.0", "", { "dependencies": { "eslint-visitor-keys": "^3.4.3" }, "peerDependencies": { "eslint": "^6.0.0 || ^7.0.0 || >=8.0.0" } }, "sha512-ayVFHdtZ+hsq1t2Dy24wCmGXGe4q9Gu3smhLYALJrr473ZH27MsnSL+LKUlimp4BWJqMDMLmPpx/Q9R3OAlL4g=="],
 
-    "browserslist/baseline-browser-mapping": ["baseline-browser-mapping@2.8.32", "", { "bin": "dist/cli.js" }, "sha512-OPz5aBThlyLFgxyhdwf/s2+8ab3OvT7AdTNvKHBwpXomIYeXqpUUuT8LrdtxZSsWJ4R4CU1un4XGh5Ez3nlTpw=="],
+    "browserslist/caniuse-lite": ["caniuse-lite@1.0.30001810", "", {}, "sha512-TITQPUkaz+aVk5GL6NhOdwk1aEaNTSDPsGFWrTuhKGtjTF70jL/Oht2W4c6rXUe5fu7Ie19VIahAXHIIiWWNeg=="],
 
     "eslint-import-resolver-node/debug": ["debug@3.2.7", "", { "dependencies": { "ms": "^2.1.1" } }, "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ=="],
 
@@ -1498,8 +1500,6 @@
 
     "posthog-js/core-js": ["core-js@3.50.0", "", {}, "sha512-BRWgOLKkFeCgRudR6zrs8p9XJZcE14grzKMMssoYrk6krtuEZ7MTKPIY5RzOnqsEKIR9kst7wNzphttraT+Yqw=="],
 
-    "posthog-js/fflate": ["fflate@0.4.8", "", {}, "sha512-FJqqoDBR00Mdj9ppamLa/Y7vxm+PRmNWA67N846RvsoYVMKB4q3y/de5PA7gUmRMYK/8CMz2GDZQmCRN1wBcWA=="],
-
     "readable-stream/safe-buffer": ["safe-buffer@5.1.2", "", {}, "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="],
 
     "safe-array-concat/isarray": ["isarray@2.0.5", "", {}, "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw=="],
@@ -1519,8 +1519,6 @@
     "string_decoder/safe-buffer": ["safe-buffer@5.1.2", "", {}, "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="],
 
     "strip-ansi-cjs/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
-
-    "three-stdlib/fflate": ["fflate@0.6.10", "", {}, "sha512-IQrh3lEPM93wVCEczc9SaAOvkmcoQn/G8Bo1e8ZPlY3X3bnAxWaBdvTdvM1hP62iZp0BXWDy4vTAy4fF0+Dlpg=="],
 
     "tunnel-rat/zustand": ["zustand@4.5.7", "", { "dependencies": { "use-sync-external-store": "^1.2.2" }, "peerDependencies": { "@types/react": ">=16.8", "immer": ">=9.0.6", "react": ">=16.8" }, "optionalPeers": ["immer"] }, "sha512-CHOUy7mu3lbD6o6LJLfllpjkzhHXSBlX8B9+qPddUsIfeF5S/UZ5q0kmCsnRqT1UHFQZchNFDDzMbQsuesHWlw=="],
 

--- a/next.config.ts
+++ b/next.config.ts
@@ -61,6 +61,12 @@ const nextConfig: NextConfig = {
       },
     ],
   },
+  async redirects() {
+    return [
+      // Legacy/bookmark path — Google sign-in lives on home
+      { source: '/login', destination: '/', permanent: false },
+    ]
+  },
   async rewrites() {
     return [
       // Proxy PostHog requests to avoid ad blockers

--- a/package.json
+++ b/package.json
@@ -65,7 +65,10 @@
     },
     "glob": {
       "minimatch": "9.0.9"
-    }
+    },
+    "browserslist": "4.28.7",
+    "@humanfs/node": "0.16.8",
+    "fflate": "0.8.3"
   },
   "devDependencies": {
     "@tailwindcss/postcss": "^4.3.3",

--- a/src/app/(dashboard)/materials/[id]/practice/page.tsx
+++ b/src/app/(dashboard)/materials/[id]/practice/page.tsx
@@ -11,6 +11,7 @@ import PracticeSettingsModal, { PracticeSettings } from "@/components/PracticeSe
 import { createClient } from "@/config/supabase/client";
 import { useXPStore } from "@/lib/stores";
 import { addXP, recordStudyActivity, batchUpdateFlashcardStatuses, applyCardReview, XP_REWARDS, type FlashcardStatusUpdate } from "@/services/activity";
+import { useAchievementsStore } from "@/lib/stores/achievementsStore";
 import { generateQuestionsFromCards, gradePracticeAnswer, type QuestionType } from "@/utils/practiceQuestions";
 import { loadStudyDeck, type StudyCardSource } from "@/lib/materials/studyCards";
 
@@ -147,6 +148,7 @@ export default function PracticePage() {
                     useXPStore.getState().fetchXPStats();
                 }
                 await recordStudyActivity({ quizzes: 1 });
+                void useAchievementsStore.getState().fetchAchievements();
                 if (deckSource === "flashcard") {
                     const supabase = createClient();
                     const { data: { user } } = await supabase.auth.getUser();
@@ -686,6 +688,7 @@ export default function PracticePage() {
                                                 useXPStore.getState().fetchXPStats();
                                             }
                                             await recordStudyActivity({ quizzes: 1 });
+                                            void useAchievementsStore.getState().fetchAchievements();
                                         };
                                         persistResults();
 

--- a/src/app/(dashboard)/materials/create/useCreateDraft.ts
+++ b/src/app/(dashboard)/materials/create/useCreateDraft.ts
@@ -14,6 +14,7 @@ import {
 } from '@/utils/generateInput';
 import { CLIENT_GENERATION_TIMEOUT_MS } from '@/utils/abort';
 import { generateItemId } from './parseBulkText';
+import { incrementStat } from '@/services/activity';
 import type {
   WizardStep,
   SourceMethod,
@@ -709,11 +710,8 @@ export function useCreateDraft() {
           throw cardsError;
         }
 
-        // Increment stats
-        void supabase.rpc('increment_stat', {
-          p_stat_name: 'flashcard_sets_created',
-          p_amount: 1,
-        });
+        // Increment stats (also runs achievement unlock via RPC)
+        await incrementStat('flashcard_sets_created', 1);
 
         clearPersistedDraft();
         setToastMessage({ kind: 'success', text: 'Material saved successfully!' });
@@ -781,10 +779,7 @@ export function useCreateDraft() {
         }
 
         // Increment stats
-        void supabase.rpc('increment_stat', {
-          p_stat_name: 'reviewers_created',
-          p_amount: 1,
-        });
+        await incrementStat('reviewers_created', 1);
 
         clearPersistedDraft();
         setToastMessage({ kind: 'success', text: 'Reviewer saved successfully!' });

--- a/src/app/(dashboard)/pomodoro/page.tsx
+++ b/src/app/(dashboard)/pomodoro/page.tsx
@@ -531,7 +531,7 @@ export default function PomodoroPage() {
                       : "bg-white text-foreground hover:bg-white/90 shadow-lg"
                   }`}
                 >
-                  {isRunning ? "Pause" : "Start"}
+                  {isRunning ? "Pause" : timeLeft < currentDuration * 60 ? "Resume" : "Start"}
                 </button>
                 <button
                   onClick={handleResetTimer}

--- a/src/app/api/generate-cards/route.ts
+++ b/src/app/api/generate-cards/route.ts
@@ -70,6 +70,7 @@ export async function POST(request: NextRequest) {
   }
 
   let billed = false;
+  let refundUserId: string | undefined;
   try {
     const file = formData.get("file") as File | null;
     const rawTextContent = formData.get("textContent");
@@ -103,6 +104,7 @@ export async function POST(request: NextRequest) {
     }
 
     const rateLimit = await checkAndIncrementAIUsage();
+    refundUserId = rateLimit.userId;
 
     if (!rateLimit.authenticated) {
       return NextResponse.json({ error: "Not authenticated" }, { status: 401 });
@@ -138,7 +140,7 @@ export async function POST(request: NextRequest) {
       throwIfAborted(signal);
       const extracted = await extractDocxText(arrayBuffer);
       if (!extracted) {
-        await refundAIGeneration();
+        await refundAIGeneration(rateLimit.userId);
         return NextResponse.json({ error: "Could not read that DOCX file." }, { status: 400 });
       }
       effectiveText = extracted.slice(0, MAX_TEXT_LENGTH);
@@ -164,7 +166,7 @@ export async function POST(request: NextRequest) {
       }
 
       if (geminiFile.state === FileState.FAILED) {
-        await refundAIGeneration();
+        await refundAIGeneration(rateLimit.userId);
         return NextResponse.json({ error: "File processing failed" }, { status: 500 });
       }
 
@@ -172,7 +174,7 @@ export async function POST(request: NextRequest) {
     }
 
     if (!fileUri && !effectiveText) {
-      await refundAIGeneration();
+      await refundAIGeneration(rateLimit.userId);
       return NextResponse.json({ error: "No file or text content provided" }, { status: 400 });
     }
 
@@ -229,7 +231,7 @@ MANDATORY:
     });
 
     if (!responseText.trim()) {
-      await refundAIGeneration();
+      await refundAIGeneration(rateLimit.userId);
       return NextResponse.json({ error: "AI returned empty response. Please try again." }, { status: 500 });
     }
 
@@ -238,13 +240,13 @@ MANDATORY:
       parsedJson = JSON.parse(responseText);
     } catch {
       console.error("[GenerateCards] Failed to parse structured response:", responseText.substring(0, 500));
-      await refundAIGeneration();
+      await refundAIGeneration(rateLimit.userId);
       return NextResponse.json({ error: "Failed to parse AI response" }, { status: 500 });
     }
 
     const parsedCards = GeminiCardsResponseSchema.safeParse(parsedJson);
     if (!parsedCards.success) {
-      await refundAIGeneration();
+      await refundAIGeneration(rateLimit.userId);
       return NextResponse.json({ error: "AI returned invalid flashcard data. Please try again." }, { status: 500 });
     }
 
@@ -259,7 +261,7 @@ MANDATORY:
     });
   } catch (error) {
     if (billed) {
-      await refundAIGeneration();
+      await refundAIGeneration(refundUserId);
     }
     if (isAbortError(error)) {
       return NextResponse.json({ error: "Generation timed out or was cancelled." }, { status: 499 });

--- a/src/app/api/generate-reviewer/route.ts
+++ b/src/app/api/generate-reviewer/route.ts
@@ -109,6 +109,7 @@ export async function POST(request: NextRequest) {
   }
 
   let billed = false;
+  let refundUserId: string | undefined;
   try {
     const file = formData.get("file") as File | null;
     const textContent = formData.get("textContent") as string | null;
@@ -139,6 +140,7 @@ export async function POST(request: NextRequest) {
     }
 
     const rateLimit = await checkAndIncrementAIUsage();
+    refundUserId = rateLimit.userId;
 
     if (!rateLimit.authenticated) {
       return NextResponse.json({ error: "Not authenticated" }, { status: 401 });
@@ -172,7 +174,7 @@ export async function POST(request: NextRequest) {
       throwIfAborted(signal);
       const extracted = await extractDocxText(arrayBuffer);
       if (!extracted) {
-        await refundAIGeneration();
+        await refundAIGeneration(rateLimit.userId);
         return NextResponse.json({ error: "Could not read that DOCX file." }, { status: 400 });
       }
       effectiveText = extracted.slice(0, MAX_TEXT_LENGTH);
@@ -198,7 +200,7 @@ export async function POST(request: NextRequest) {
       }
 
       if (geminiFile.state === FileState.FAILED) {
-        await refundAIGeneration();
+        await refundAIGeneration(rateLimit.userId);
         return NextResponse.json({ error: "File processing failed" }, { status: 500 });
       }
 
@@ -206,7 +208,7 @@ export async function POST(request: NextRequest) {
     }
 
     if (!fileUri && !effectiveText) {
-      await refundAIGeneration();
+      await refundAIGeneration(rateLimit.userId);
       return NextResponse.json({ error: "No file or text content provided" }, { status: 400 });
     }
 
@@ -279,7 +281,7 @@ COLOR OPTIONS for categories: #E0F2FE, #DCFCE7, #FEF3C7, #FCE7F3, #E0E7FF, #F3E8
     });
 
     if (!responseText.trim()) {
-      await refundAIGeneration();
+      await refundAIGeneration(rateLimit.userId);
       return NextResponse.json({ error: "AI returned empty response. Please try again." }, { status: 500 });
     }
 
@@ -288,13 +290,13 @@ COLOR OPTIONS for categories: #E0F2FE, #DCFCE7, #FEF3C7, #FCE7F3, #E0E7FF, #F3E8
       parsedJson = JSON.parse(responseText);
     } catch {
       console.error("[GenerateReviewer] Failed to parse structured response:", responseText.substring(0, 500));
-      await refundAIGeneration();
+      await refundAIGeneration(rateLimit.userId);
       return NextResponse.json({ error: "Failed to parse AI response. Please try again." }, { status: 500 });
     }
 
     const parsed = GeminiReviewerResponseSchema.safeParse(parsedJson);
     if (!parsed.success) {
-      await refundAIGeneration();
+      await refundAIGeneration(rateLimit.userId);
       return NextResponse.json({ error: "AI returned invalid reviewer data. Please try again." }, { status: 500 });
     }
 
@@ -309,7 +311,7 @@ COLOR OPTIONS for categories: #E0F2FE, #DCFCE7, #FEF3C7, #FCE7F3, #E0E7FF, #F3E8
     });
   } catch (error) {
     if (billed) {
-      await refundAIGeneration();
+      await refundAIGeneration(refundUserId);
     }
     if (isAbortError(error)) {
       return NextResponse.json({ error: "Generation timed out or was cancelled." }, { status: 499 });

--- a/src/components/CaptchaModal.tsx
+++ b/src/components/CaptchaModal.tsx
@@ -1,7 +1,7 @@
 "use client";
 
-import { useRef, useCallback, useEffect } from "react";
-import { X, ShieldCheck } from "lucide-react";
+import { useRef, useCallback, useState } from "react";
+import { X, ShieldCheck, AlertTriangle, RefreshCw } from "lucide-react";
 import { Turnstile } from "@marsidev/react-turnstile";
 import type { TurnstileInstance } from "@marsidev/react-turnstile";
 import { Modal } from "@/components/ui";
@@ -15,9 +15,22 @@ interface Props {
 
 export default function CaptchaModal({ isOpen, onClose, onVerify, onError }: Props) {
     const captchaRef = useRef<TurnstileInstance>(null);
-    const siteKey = process.env.NEXT_PUBLIC_TURNSTILE_SITE_KEY;
+    const siteKey = (process.env.NEXT_PUBLIC_TURNSTILE_SITE_KEY ?? "").trim();
+    const [widgetError, setWidgetError] = useState<string | null>(null);
+    const [retryCount, setRetryCount] = useState(0);
+    const [wasOpen, setWasOpen] = useState(isOpen);
+
+    // Reset widget state when the modal newly opens (React render-time adjust pattern).
+    if (isOpen !== wasOpen) {
+        setWasOpen(isOpen);
+        if (isOpen) {
+            setWidgetError(null);
+            setRetryCount((count) => count + 1);
+        }
+    }
 
     const handleVerify = useCallback((token: string) => {
+        setWidgetError(null);
         onVerify(token);
         onClose();
     }, [onVerify, onClose]);
@@ -27,17 +40,14 @@ export default function CaptchaModal({ isOpen, onClose, onVerify, onError }: Pro
     }, []);
 
     const handleError = useCallback(() => {
-        captchaRef.current?.reset();
+        setWidgetError("Verification failed to load. Check your connection and try again.");
         onError?.();
     }, [onError]);
 
-    useEffect(() => {
-        if (isOpen) {
-            captchaRef.current?.reset();
-        }
-    }, [isOpen]);
-
-    if (!siteKey) return null;
+    const handleRetry = useCallback(() => {
+        setWidgetError(null);
+        setRetryCount((count) => count + 1);
+    }, []);
 
     return (
         <Modal open={isOpen} onClose={onClose} labelledBy="captcha-modal-title">
@@ -57,19 +67,55 @@ export default function CaptchaModal({ isOpen, onClose, onVerify, onError }: Pro
                     <X size={18} aria-hidden="true" />
                 </button>
             </div>
-            <p className="text-sm text-muted-foreground mb-4 text-pretty">
-                Complete the check to continue. This usually takes a few seconds.
-            </p>
-            <div className="flex justify-center">
-                <Turnstile
-                    ref={captchaRef}
-                    siteKey={siteKey}
-                    onSuccess={handleVerify}
-                    onExpire={handleExpire}
-                    onError={handleError}
-                    options={{ theme: "light" }}
-                />
-            </div>
+
+            {!siteKey ? (
+                <div
+                    className="rounded-md border border-danger bg-danger-subtle p-3 text-danger-text text-sm"
+                    role="alert"
+                >
+                    <div className="flex items-start gap-2">
+                        <AlertTriangle size={16} className="mt-0.5 shrink-0" aria-hidden="true" />
+                        <div>
+                            <p className="font-medium">Human verification is not configured</p>
+                            <p className="mt-1 text-pretty opacity-90">
+                                Set <code className="text-xs">NEXT_PUBLIC_TURNSTILE_SITE_KEY</code> for this
+                                environment. Server-side Turnstile checks remain required for generation.
+                            </p>
+                        </div>
+                    </div>
+                </div>
+            ) : (
+                <>
+                    <p className="text-sm text-muted-foreground mb-4 text-pretty">
+                        Complete the check to continue. This usually takes a few seconds.
+                    </p>
+                    <div className="flex min-h-[65px] flex-col items-center justify-center gap-3">
+                        {widgetError ? (
+                            <div className="w-full rounded-md border border-danger bg-danger-subtle p-3 text-danger-text text-sm" role="alert">
+                                <p>{widgetError}</p>
+                                <button
+                                    type="button"
+                                    onClick={handleRetry}
+                                    className="mt-2 inline-flex items-center gap-1.5 text-sm font-medium underline-offset-2 hover:underline"
+                                >
+                                    <RefreshCw size={14} aria-hidden="true" />
+                                    Retry
+                                </button>
+                            </div>
+                        ) : (
+                            <Turnstile
+                                key={`turnstile-${retryCount}`}
+                                ref={captchaRef}
+                                siteKey={siteKey}
+                                onSuccess={handleVerify}
+                                onExpire={handleExpire}
+                                onError={handleError}
+                                options={{ theme: "light", appearance: "always" }}
+                            />
+                        )}
+                    </div>
+                </>
+            )}
         </Modal>
     );
 }

--- a/src/components/ShareModal.tsx
+++ b/src/components/ShareModal.tsx
@@ -200,7 +200,7 @@ export default function ShareModal({ isOpen, onClose, materialId, materialType, 
                         setCustomCode(e.target.value.toLowerCase().replace(/[^a-z0-9-]/g, ''))
                         setCodeError("")
                       }}
-                      placeholder="my-custom-code"
+                      placeholder="my-study-deck-01"
                       className="flex-1 px-3 py-2 border border-border rounded-lg text-sm focus:outline-none focus:border-primary"
                     />
                     <button
@@ -219,7 +219,7 @@ export default function ShareModal({ isOpen, onClose, materialId, materialType, 
                   </div>
                   {codeError && <p className="text-red-500 text-xs mt-1">{codeError}</p>}
                   <p className="text-xs text-muted-foreground mt-1">
-                    8-64 characters, lowercase letters, numbers, and hyphens only
+                    12-64 characters, lowercase letters, numbers, and hyphens only
                   </p>
                 </div>
               ) : (
@@ -274,7 +274,7 @@ export default function ShareModal({ isOpen, onClose, materialId, materialType, 
                 />
                 {codeError && <p className="text-red-500 text-xs mt-1">{codeError}</p>}
                 <p className="text-xs text-muted-foreground mt-1">
-                  8-64 characters, lowercase letters, numbers, and hyphens only
+                  12-64 characters, lowercase letters, numbers, and hyphens only
                 </p>
               </div>
 

--- a/src/components/Turnstile/TurnstileWidget.tsx
+++ b/src/components/Turnstile/TurnstileWidget.tsx
@@ -3,6 +3,7 @@
 import { useRef, useState, useCallback } from 'react'
 import { Turnstile } from '@marsidev/react-turnstile'
 import type { TurnstileInstance } from '@marsidev/react-turnstile'
+import { AlertTriangle } from 'lucide-react'
 
 interface TurnstileWidgetProps {
   onVerify: (token: string) => void
@@ -12,7 +13,7 @@ interface TurnstileWidgetProps {
 
 export default function TurnstileWidget({ onVerify, onExpire, onError }: TurnstileWidgetProps) {
   const captchaRef = useRef<TurnstileInstance>(null)
-  const siteKey = process.env.NEXT_PUBLIC_TURNSTILE_SITE_KEY
+  const siteKey = (process.env.NEXT_PUBLIC_TURNSTILE_SITE_KEY ?? '').trim()
 
   const handleVerify = useCallback((token: string) => {
     onVerify(token)
@@ -27,19 +28,31 @@ export default function TurnstileWidget({ onVerify, onExpire, onError }: Turnsti
   }, [onError])
 
   if (!siteKey) {
-    console.warn('Turnstile site key not configured')
-    return null
+    return (
+      <div
+        className="my-4 rounded-md border border-danger bg-danger-subtle p-3 text-danger-text text-sm"
+        role="alert"
+      >
+        <div className="flex items-start gap-2">
+          <AlertTriangle size={16} className="mt-0.5 shrink-0" aria-hidden="true" />
+          <p>
+            Human verification is not configured. Set{" "}
+            <code className="text-xs">NEXT_PUBLIC_TURNSTILE_SITE_KEY</code>.
+          </p>
+        </div>
+      </div>
+    )
   }
 
   return (
-    <div className="flex justify-center my-4">
+    <div className="flex min-h-[65px] justify-center my-4">
       <Turnstile
         ref={captchaRef}
         siteKey={siteKey}
         onSuccess={handleVerify}
         onExpire={handleExpire}
         onError={handleError}
-        options={{ theme: 'light' }}
+        options={{ theme: 'light', appearance: 'always' }}
       />
     </div>
   )

--- a/src/config/supabase/service.ts
+++ b/src/config/supabase/service.ts
@@ -1,0 +1,21 @@
+import { createClient } from '@supabase/supabase-js'
+
+/**
+ * Service-role Supabase client (bypasses RLS). Server-only.
+ * Requires SUPABASE_SECRET_KEY — never import this from client components.
+ */
+export function createServiceSupabaseClient() {
+  const url = process.env.NEXT_PUBLIC_SUPABASE_URL
+  const serviceKey = process.env.SUPABASE_SECRET_KEY
+
+  if (!url || !serviceKey) {
+    throw new Error('Missing Supabase service role credentials (SUPABASE_SECRET_KEY)')
+  }
+
+  return createClient(url, serviceKey, {
+    auth: {
+      autoRefreshToken: false,
+      persistSession: false,
+    },
+  })
+}

--- a/src/lib/schemas/sharing.ts
+++ b/src/lib/schemas/sharing.ts
@@ -5,8 +5,23 @@ const ShareCodeBaseSchema = z
   .max(64, 'Share code must be at most 64 characters')
   .regex(/^[a-z0-9-]+$/, 'Only lowercase letters, numbers, and hyphens allowed')
 
+/** Reject obviously weak custom codes (still allow auto 16-char CSPRNG codes). */
+function isWeakShareCode(code: string): boolean {
+  if (/^-|-$|--/.test(code)) return true
+  if (/^(.)\1+$/.test(code)) return true // all same char
+  if (/^(?:abc|abcd|abcdef|qwerty|password|share|test|admin|123456|012345)/.test(code)) return true
+  if (/^\d+$/.test(code)) return true // digits only
+  const unique = new Set(code.replace(/-/g, '')).size
+  if (unique < 4) return true
+  return false
+}
+
 export const ShareCodeSchema = ShareCodeBaseSchema.min(3, 'Share code must be at least 3 characters')
-export const ShareCodeCreateSchema = ShareCodeBaseSchema.min(8, 'Share code must be at least 8 characters')
+export const ShareCodeCreateSchema = ShareCodeBaseSchema
+  .min(12, 'Share code must be at least 12 characters')
+  .refine((code) => !isWeakShareCode(code), {
+    message: 'Share code is too weak — avoid repeated, sequential, or common patterns',
+  })
 
 export const ShareMaterialTypeSchema = z.enum(['flashcard_set', 'reviewer'])
 export type ShareMaterialType = z.infer<typeof ShareMaterialTypeSchema>

--- a/src/lib/supabase/009_revoke_refund_ai_usage.sql
+++ b/src/lib/supabase/009_revoke_refund_ai_usage.sql
@@ -1,0 +1,212 @@
+-- 009_revoke_refund_ai_usage.sql
+-- STATUS: NOT applied to live DB until owner runs it in Supabase SQL editor
+--         (or via migration runner). Do not assume PostgREST grants are live.
+--
+-- Fixes:
+-- 1) HIGH — public.refund_ai_usage() was EXECUTE-granted to authenticated,
+--    so any signed-in user could refund their own AI quota via PostgREST.
+--    Revoke client access; refunds go through service-role-only RPC.
+-- 2) HIGH — achievements stuck at 0/60: the 5-arg record_study_activity
+--    (what the app calls with p_activity_date) never ran check_achievements;
+--    increment_stat still called public.check_achievements() after it moved
+--    to private (so set-create stats/unlocks silently failed).
+
+create schema if not exists private;
+
+-- ---------------------------------------------------------------------------
+-- 1. Service-role-only AI refund (by user id — auth.uid() is null for service)
+-- ---------------------------------------------------------------------------
+create or replace function private.refund_ai_usage_for(p_user_id uuid)
+returns boolean
+language plpgsql
+security definer
+set search_path = ''
+as $$
+declare
+  v_today date := (now() at time zone 'utc')::date;
+begin
+  if p_user_id is null then
+    return false;
+  end if;
+
+  update public.ai_usage
+  set generation_count = greatest(generation_count - 1, 0),
+      updated_at = now()
+  where user_id = p_user_id
+    and reset_date = v_today;
+
+  return found;
+end;
+$$;
+
+create or replace function public.refund_ai_usage_for(p_user_id uuid)
+returns boolean
+language plpgsql
+security definer
+set search_path = ''
+as $$
+begin
+  -- Callable only with SUPABASE_SECRET_KEY / service_role (grants below).
+  return private.refund_ai_usage_for(p_user_id);
+end;
+$$;
+
+revoke all on function public.refund_ai_usage_for(uuid) from public;
+revoke all on function public.refund_ai_usage_for(uuid) from anon;
+revoke all on function public.refund_ai_usage_for(uuid) from authenticated;
+grant execute on function public.refund_ai_usage_for(uuid) to service_role;
+
+revoke all on function private.refund_ai_usage_for(uuid) from public;
+revoke all on function private.refund_ai_usage_for(uuid) from anon;
+revoke all on function private.refund_ai_usage_for(uuid) from authenticated;
+
+-- Revoke the legacy no-arg client-callable refund (signature from 006).
+revoke all on function public.refund_ai_usage() from public;
+revoke all on function public.refund_ai_usage() from anon;
+revoke all on function public.refund_ai_usage() from authenticated;
+-- Keep service_role able to call the legacy wrapper only if it still needs
+-- auth.uid() context; prefer refund_ai_usage_for going forward.
+grant execute on function public.refund_ai_usage() to service_role;
+
+-- ---------------------------------------------------------------------------
+-- 2. Achievements: fix unlock path after private.check_achievements move
+-- ---------------------------------------------------------------------------
+create or replace function public.record_study_activity(
+  p_minutes integer default 0,
+  p_flashcards integer default 0,
+  p_quizzes integer default 0,
+  p_pomodoros integer default 0,
+  p_activity_date date default null
+) returns void
+language plpgsql
+security definer
+set search_path = ''
+as $$
+declare
+  v_user_id uuid := auth.uid();
+  v_today date := coalesce(p_activity_date, current_date);
+begin
+  if v_user_id is null then
+    raise exception 'Authentication required';
+  end if;
+
+  insert into public.study_activity (
+    user_id, activity_date, minutes_studied, flashcards_reviewed, quizzes_completed, pomodoro_sessions
+  )
+  values (v_user_id, v_today, p_minutes, p_flashcards, p_quizzes, p_pomodoros)
+  on conflict (user_id, activity_date) do update set
+    minutes_studied     = public.study_activity.minutes_studied     + p_minutes,
+    flashcards_reviewed = public.study_activity.flashcards_reviewed + p_flashcards,
+    quizzes_completed   = public.study_activity.quizzes_completed   + p_quizzes,
+    pomodoro_sessions   = public.study_activity.pomodoro_sessions   + p_pomodoros,
+    updated_at = now();
+
+  update public.user_stats
+     set total_study_minutes = total_study_minutes + p_minutes,
+         quizzes_completed   = user_stats.quizzes_completed + p_quizzes,
+         pomodoro_sessions   = user_stats.pomodoro_sessions + p_pomodoros,
+         updated_at = now()
+   where user_id = v_user_id;
+
+  perform private.update_study_streak(v_user_id, v_today);
+  perform private.check_achievements();
+end;
+$$;
+
+revoke all on function public.record_study_activity(integer, integer, integer, integer, date) from public;
+grant execute on function public.record_study_activity(integer, integer, integer, integer, date) to authenticated, service_role;
+
+create or replace function public.increment_stat(p_stat_name text, p_amount integer default 1)
+returns void
+language plpgsql
+security definer
+set search_path = ''
+as $$
+declare
+  v_safe_amount integer;
+  v_user_id uuid := auth.uid();
+begin
+  if v_user_id is null then
+    raise exception 'Not authenticated';
+  end if;
+
+  if p_amount is null or p_amount < 1 then
+    v_safe_amount := 1;
+  elsif p_amount > 500 then
+    v_safe_amount := 500;
+  else
+    v_safe_amount := p_amount;
+  end if;
+
+  case p_stat_name
+    when 'flashcards_mastered' then
+      update public.user_stats set flashcards_mastered = flashcards_mastered + v_safe_amount, updated_at = now() where user_id = v_user_id;
+    when 'perfect_quizzes' then
+      update public.user_stats set perfect_quizzes = perfect_quizzes + v_safe_amount, updated_at = now() where user_id = v_user_id;
+    when 'quizzes_completed' then
+      update public.user_stats set quizzes_completed = quizzes_completed + v_safe_amount, updated_at = now() where user_id = v_user_id;
+    when 'pomodoro_sessions' then
+      update public.user_stats set pomodoro_sessions = pomodoro_sessions + v_safe_amount, updated_at = now() where user_id = v_user_id;
+    when 'flashcard_sets_created' then
+      update public.user_stats set flashcard_sets_created = flashcard_sets_created + v_safe_amount, updated_at = now() where user_id = v_user_id;
+    when 'reviewers_created' then
+      update public.user_stats set reviewers_created = reviewers_created + v_safe_amount, updated_at = now() where user_id = v_user_id;
+    when 'materials_uploaded' then
+      update public.user_stats set materials_uploaded = materials_uploaded + v_safe_amount, updated_at = now() where user_id = v_user_id;
+    else
+      return;
+  end case;
+
+  perform private.check_achievements();
+end;
+$$;
+
+revoke all on function public.increment_stat(text, integer) from public;
+grant execute on function public.increment_stat(text, integer) to authenticated, service_role;
+
+-- Sync achievements whenever the client fetches them (heals already-bumped stats).
+create or replace function public.get_user_achievements()
+returns table (
+  id text,
+  title text,
+  description text,
+  icon text,
+  color text,
+  bg text,
+  progress integer,
+  requirement_value integer,
+  unlocked boolean,
+  unlocked_at timestamptz
+)
+language plpgsql
+security definer
+set search_path = ''
+as $$
+begin
+  if auth.uid() is null then
+    return;
+  end if;
+
+  perform private.check_achievements();
+
+  return query
+  select
+    ad.id,
+    ad.title,
+    ad.description,
+    ad.icon,
+    ad.color,
+    ad.bg,
+    coalesce(ua.progress, 0) as progress,
+    ad.requirement_value,
+    coalesce(ua.unlocked, false) as unlocked,
+    ua.unlocked_at
+  from public.achievement_definitions ad
+  left join public.user_achievements ua
+    on ua.achievement_id = ad.id and ua.user_id = auth.uid()
+  order by ua.unlocked desc nulls last, ad.id;
+end;
+$$;
+
+revoke all on function public.get_user_achievements() from public;
+grant execute on function public.get_user_achievements() to authenticated, service_role;

--- a/src/services/activity.ts
+++ b/src/services/activity.ts
@@ -1,4 +1,5 @@
 import { createClient } from "@/config/supabase/client";
+import { useAchievementsStore } from "@/lib/stores/achievementsStore";
 import { splitIntoChunks } from "@/utils/chunks";
 import { qualityFromCorrect, reviewSM2 } from "@/utils/sm2";
 
@@ -30,6 +31,11 @@ const VALID_STAT_NAMES = [
 ] as const;
 
 type ValidStatName = typeof VALID_STAT_NAMES[number];
+
+function refreshAchievementsQuietly() {
+    void useAchievementsStore.getState().fetchAchievements().catch(() => {});
+}
+
 
 /**
  * Get local date string in YYYY-MM-DD format for activity tracking
@@ -69,6 +75,9 @@ export async function recordStudyActivity(options: {
         p_pomodoros: safePomodoros,
         p_activity_date: localDate
     });
+    if (!error) {
+        refreshAchievementsQuietly();
+    }
     return { error };
 }
 
@@ -153,6 +162,9 @@ export async function incrementStat(statName: string, amount: number = 1) {
             lastError = error;
             break;
         }
+    }
+    if (!lastError) {
+        refreshAchievementsQuietly();
     }
     return { error: lastError };
 }

--- a/src/services/rateLimit.ts
+++ b/src/services/rateLimit.ts
@@ -145,13 +145,31 @@ export async function getRemainingAIGenerations(): Promise<RateLimitResult> {
   }
 }
 
-export async function refundAIGeneration(): Promise<boolean> {
-  const supabase = await createServerSupabaseClient()
-  const { data, error } = await supabase.rpc('refund_ai_usage')
-  if (error) {
-    console.error('Failed to refund AI usage:', error.message || error.code)
+/**
+ * Refund one AI generation for a user after a failed generate.
+ * Uses SUPABASE_SECRET_KEY / service role only — public.refund_ai_usage()
+ * is revoked from authenticated/anon (see migration 009).
+ */
+export async function refundAIGeneration(userId?: string): Promise<boolean> {
+  if (!userId) {
+    console.error('Failed to refund AI usage: missing userId')
     return false
   }
-  return Boolean(data)
+
+  try {
+    const { createServiceSupabaseClient } = await import('@/config/supabase/service')
+    const supabase = createServiceSupabaseClient()
+    const { data, error } = await supabase.rpc('refund_ai_usage_for', {
+      p_user_id: userId,
+    })
+    if (error) {
+      console.error('Failed to refund AI usage:', error.message || error.code)
+      return false
+    }
+    return Boolean(data)
+  } catch (err) {
+    console.error('Failed to refund AI usage:', err instanceof Error ? err.message : err)
+    return false
+  }
 }
 

--- a/src/tests/api/share.schema.test.ts
+++ b/src/tests/api/share.schema.test.ts
@@ -33,7 +33,15 @@ describe('share API schemas', () => {
     }).success).toBe(false)
     expect(SharePatchSchema.safeParse({
       shareId: VALID_UUID,
-      newCode: 'custom-code',
+      newCode: 'custom-code', // too short (<12)
+    }).success).toBe(false)
+    expect(SharePatchSchema.safeParse({
+      shareId: VALID_UUID,
+      newCode: 'aaaaaaaaaaaa', // weak repeated
+    }).success).toBe(false)
+    expect(SharePatchSchema.safeParse({
+      shareId: VALID_UUID,
+      newCode: 'my-study-deck-01',
     }).success).toBe(true)
   })
 })


### PR DESCRIPTION
## Summary

QA / OWASP hardening on DeepTerm without a live pentest. Addresses empty Turnstile modal, stuck achievements (0/60), `/login` 404, client-callable AI refund RPC, Pomodoro Resume label, and weak custom share codes.

### Severity table

| Severity | Area | Issue | OWASP | Fix |
|---|---|---|---|---|
| HIGH | AI usage | `public.refund_ai_usage()` executable by `authenticated` → quota refund abuse | A01 Broken Access Control | Migration `009` revokes client EXECUTE; server refunds via `refund_ai_usage_for(p_user_id)` + `SUPABASE_SECRET_KEY` only |
| HIGH | Turnstile UI | Empty “Verify you're human” modal / blank widget | A05 Security Misconfiguration (UX) | CaptchaModal shows clear error if site key missing; remount + retry on widget error; server verify unchanged |
| HIGH | Achievements | Practice awarded XP but achievements stayed 0/60 (First Steps / quiz unlocks) | A04 Insecure Design | 5-arg `record_study_activity` + `increment_stat` now call `private.check_achievements()`; `get_user_achievements` syncs on read; client awaits `incrementStat` + refreshes store |
| — | Auth UX | `/login` 404 | — | Next.js redirect `/login` → `/` (Google sign-in entry) |
| LOW | Pomodoro | Paused timer button still said “Start” | — | Label shows **Resume** when paused |
| MEDIUM | Sharing | Custom share codes allowed weak short values (min 8) | A07 Identification / Auth failures (guessable codes) | Min length 12 + reject weak patterns; auto 16-char CSPRNG unchanged |

## How to verify

1. **SQL (required):** apply `src/lib/supabase/009_revoke_refund_ai_usage.sql` in Supabase SQL editor for project `lopurzvtignkqyubqgtz` if not auto-applied. Confirm `refund_ai_usage` is not executable by `authenticated`/`anon`; `refund_ai_usage_for` is `service_role` only.
2. **Turnstile:** open create-material → Verify. With site key set, widget mounts (retry on error). With key empty/unset, modal shows configuration error — not a blank panel. Generation still requires server Turnstile verification.
3. **Achievements:** create a flashcard set → First Steps unlocks; complete a practice test → quiz progress/unlock updates (refresh Achievements page if needed).
4. **`/login`:** visit `/login` → lands on `/`.
5. **Pomodoro:** start → pause → primary button says Resume.
6. **Share codes:** custom code `<12` chars or `aaaaaaaaaaaa` rejected; auto-generated links still 16 chars.

## Remaining known issues

- Vercel Hobby production deploy may reject **fourcrew** commits; merge/deploy may need Gab (`gabshit` / `4regab`) if Hobby blocks this author.
- Active live pentest was **not** done in this PR.
- Pre-existing lint warnings remain on account page (`window.location.href`) and practice `useCallback` deps — not introduced here.
- Until migration `009` is applied, generate failure refunds via service-role RPC will no-op/log errors (fail closed vs leaving the old client-callable refund).

## Deploy note

Owner must apply SQL migration **009** in Supabase. Do not replay `001`/`002`/`006`.