### PR TITLE
chore: kill dead dashboard ui exports

### DIFF
--- a/src/app/(dashboard)/dashboard/DashboardClient.tsx
+++ b/src/app/(dashboard)/dashboard/DashboardClient.tsx
@@ -109,30 +109,7 @@ function getGreeting(): string {
   return "Good night";
 }
 
-export function DashboardHeader({ initialData }: { initialData?: DashboardData | null }) {
-  const greeting = getGreeting();
-  const firstName = initialData?.profile?.full_name?.split(" ")[0] || "there";
 
-  return (
-    <div className="flex flex-wrap items-end justify-between gap-4">
-      <div>
-        <h1 className="display-lg tracking-tight text-ink">
-          {greeting}, {firstName}
-        </h1>
-        <p className="body text-muted mt-1">Pick up where you left off.</p>
-      </div>
-
-      <ButtonLink href="/materials/create" size="sm" variant="primary" className="gap-1.5">
-        <Plus size={16} aria-hidden="true" />
-        <span>Create Material</span>
-      </ButtonLink>
-    </div>
-  );
-}
-
-export function DueTodayList() {
-  return null;
-}
 
 export default function DashboardClient({
   initialData,

--- a/src/components/EmotionalAssets.tsx
+++ b/src/components/EmotionalAssets.tsx
@@ -138,45 +138,7 @@ export const FloatingOrb = ({ state = "idle" }: { state?: "idle" | "thinking" | 
 };
 
 // --- Success Checkmark Explosion ---
-export const SuccessCheck = () => {
-    return (
-        <div className="relative w-20 h-20 flex items-center justify-center">
-            <motion.div
-                initial={{ scale: 0 }}
-                animate={{ scale: 1 }}
-                transition={{ type: "spring", stiffness: 200, damping: 15 }}
-                className="w-16 h-16 bg-green-500 rounded-full flex items-center justify-center shadow-lg z-10"
-            >
-                <motion.svg
-                    width="32"
-                    height="32"
-                    viewBox="0 0 24 24"
-                    fill="none"
-                    stroke="white"
-                    strokeWidth="3"
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                    initial={{ pathLength: 0, opacity: 0 }}
-                    animate={{ pathLength: 1, opacity: 1 }}
-                    transition={{ delay: 0.2, duration: 0.5 }}
-                >
-                    <polyline points="20 6 9 17 4 12" />
-                </motion.svg>
-            </motion.div>
-
-            {/* Ripple rings */}
-            {[0, 1, 2].map((i) => (
-                <motion.div
-                    key={i}
-                    className="absolute inset-0 border-2 border-green-500 rounded-full"
-                    initial={{ scale: 0.8, opacity: 1 }}
-                    animate={{ scale: 2, opacity: 0 }}
-                    transition={{ duration: 1, delay: i * 0.2, repeat: Infinity }}
-                />
-            ))}
-        </div>
-    );
-};
+// REMOVED: SuccessCheck is unused and obsolete.
 
 // --- Encouragement Toast ---
 export const EncouragementToast = ({ message, isVisible, onClose }: { message: string, isVisible: boolean, onClose: () => void }) => {

--- a/src/components/ui/Skeleton.tsx
+++ b/src/components/ui/Skeleton.tsx
@@ -10,20 +10,6 @@ export function SkeletonBar({ className }: { className?: string }) {
   );
 }
 
-export function SkeletonLine({
-  slot = "h-6",
-  bar = "h-3 w-2/3",
-}: {
-  slot?: string;
-  bar?: string;
-}) {
-  return (
-    <span className={cn("flex items-center", slot)}>
-      <SkeletonBar className={cn("max-w-full", bar)} />
-    </span>
-  );
-}
-
 export function Arrive({
   children,
   className,

--- a/src/components/ui/index.ts
+++ b/src/components/ui/index.ts
@@ -78,7 +78,6 @@ export {
   MaterialCardSkeleton,
   MaterialRowSkeleton,
   SkeletonBar,
-  SkeletonLine,
   StatTileSkeleton,
 } from "./Skeleton";
 export { Reveal } from "./Reveal";

--- a/src/tests/dashboardHeader.test.ts
+++ b/src/tests/dashboardHeader.test.ts
@@ -3,7 +3,7 @@ import { useXPStore } from '../lib/stores/xpStore'
 import { useProfileStore } from '../lib/stores/profileStore'
 import { getRankTitle, calculateProgressPercent } from '../utils/xp'
 
-describe('DashboardHeader Component Logic', () => {
+describe('Dashboard XP Display Logic', () => {
   beforeEach(() => {
     useXPStore.setState({
       stats: null,


### PR DESCRIPTION
## DT-A: Dead Dashboard UI Cleanup

Remove unused exports confirmed dead via grep:

1. **DashboardHeader** and **DueTodayList** from  — page imports only default export + types
2. **SuccessCheck** from  — no references
3. **SkeletonLine** from  and  — no references  
4. ~~outline variant~~ — kept (legacy alias for `secondary`, still valid)

Renamed test suite in  from "DashboardHeader Component Logic" to "Dashboard XP Display Logic" — tests utility functions (getRankTitle, calculateProgressPercent), not the removed component.

### Proof
- `bun test src/tests/dashboardHeader.test.ts` ✅ 18 pass
- `bun run lint` ✅ 0 errors (2 pre-existing warnings)
- No imports of removed symbols via `grep`

### Files Changed (5)
- `src/app/(dashboard)/dashboard/DashboardClient.tsx`
- `src/components/EmotionalAssets.tsx`
- `src/components/ui/Skeleton.tsx`
- `src/components/ui/index.ts`
- `src/tests/dashboardHeader.test.ts`